### PR TITLE
Move react-dom dep to main `dependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "webpack": "1.12.2",
     "webpack-dev-middleware": "1.2.0",
     "webpack-hot-middleware": "2.4.1",
-    "webpack-merge": "0.2.0"
+    "webpack-merge": "0.2.0",
+    "react-dom": "~0.14.2"
   },
   "peerDependencies": {
     "react": ">=0.14.0"
@@ -74,8 +75,7 @@
     "mocha": "~2.3.3",
     "postcss-modules-extract-imports": "~1.0.0",
     "postcss-modules-scope": "~1.0.0",
-    "react": "~0.14.2",
-    "react-dom": "~0.14.2"
+    "react": "~0.14.2"
   },
   "scripts": {
     "test": "npm run lint && npm run mocha && npm run build",


### PR DESCRIPTION
Using `styleguidist server`, I get an error about missing dependency, which was listed in dev-dependencies, and is not installed on `npm i`.

```
ERROR in /Users/operatino/.nvm/versions/node/v4.2.1/lib/~/react-styleguidist/src/index.js
Module not found: Error: Cannot resolve module 'react-dom' in /Users/operatino/.nvm/versions/node/v4.2.1/lib/node_modules/react-styleguidist/src
 @ /Users/operatino/.nvm/versions/node/v4.2.1/lib/~/react-styleguidist/src/index.js 9:16-36

ERROR in /Users/operatino/.nvm/versions/node/v4.2.1/lib/~/react-styleguidist/src/components/Preview/Preview.js
Module not found: Error: Cannot resolve module 'react-dom' in /Users/operatino/.nvm/versions/node/v4.2.1/lib/node_modules/react-styleguidist/src/components/Preview
 @ /Users/operatino/.nvm/versions/node/v4.2.1/lib/~/react-styleguidist/src/components/Preview/Preview.js 31:16-36
```