### PR TITLE
Make css modules class names unique

### DIFF
--- a/src/make-webpack-config.js
+++ b/src/make-webpack-config.js
@@ -10,7 +10,7 @@ var config = require('../src/utils/config');
 
 module.exports = function(env) {
 	var isProd = env === 'production';
-	var cssLoader = 'css?modules&importLoaders=1&localIdentName=ReactStyleguidist-[name]__[local]!postcss';
+	var cssLoader = 'css?modules&importLoaders=1&localIdentName=ReactStyleguidist-[name]__[local]---[hash:base64:5]!postcss';
 
 	var codeMirrorPath = getInstalledPath('codemirror', true);
 	var reactTransformPath = getInstalledPath('babel-plugin-react-transform', true);


### PR DESCRIPTION
I have a problem where I use a css module style called `container` in my components, but that conflicts with the styleguide styles. Add a hash to make the class names unique.