### PR TITLE
Bump react-docgen to 2.7.0 to support flow proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "postcss-loader": "0.8.0",
     "prettyjson": "1.1.3",
     "react-codemirror": "0.2.3",
-    "react-docgen": "2.5.0",
+    "react-docgen": "2.7.0",
     "react-sticky": "~3.0.0",
     "react-transform-catch-errors": "1.0.1",
     "react-transform-hmr": "1.0.1",


### PR DESCRIPTION
See also #78 