### PR TITLE
Handle unknown proptypes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -382,6 +382,23 @@ export default class Wrapper extends Component {
 2. Press the ![Debugger](http://wow.sapegin.me/image/2n2z0b0l320m/debugger.png) button in your browser’s developer tools.
 3. Press the ![Continue](http://wow.sapegin.me/image/2d2z1Y2o1z1m/continue.png) button and the debugger will stop exception a the next exception.
 
+### Why does the style guide list one of my prop types as unknown?
+
+This occurs when you are assigning props via getDefaultProps that are not listed within the components propTypes.
+
+For example, the color prop here is assigned via getDefaultProps but missing from the propTypes, therefore the styleguide is unable to display the correct propType.
+
+```javascript
+Button.propTypes = {
+	children: PropTypes.string.isRequired,
+	size: PropTypes.oneOf(['small', 'normal', 'large']),
+};
+
+Button.defaultProps = {
+	color: '#333',
+	size: 'normal'
+};
+```
 ## Similar projects
 
 * [heatpack](https://github.com/insin/react-heatpack), a quick to setup hot-reloaded development server for React components.

--- a/Readme.md
+++ b/Readme.md
@@ -384,9 +384,9 @@ export default class Wrapper extends Component {
 
 ### Why does the style guide list one of my prop types as unknown?
 
-This occurs when you are assigning props via getDefaultProps that are not listed within the components propTypes.
+This occurs when you are assigning props via `getDefaultProps` that are not listed within the components `propTypes`.
 
-For example, the color prop here is assigned via getDefaultProps but missing from the propTypes, therefore the styleguide is unable to display the correct propType.
+For example, the color prop here is assigned via `getDefaultProps` but missing from the `propTypes`, therefore the styleguide is unable to display the correct prop type.
 
 ```javascript
 Button.propTypes = {

--- a/Readme.md
+++ b/Readme.md
@@ -382,7 +382,7 @@ export default class Wrapper extends Component {
 2. Press the ![Debugger](http://wow.sapegin.me/image/2n2z0b0l320m/debugger.png) button in your browser’s developer tools.
 3. Press the ![Continue](http://wow.sapegin.me/image/2d2z1Y2o1z1m/continue.png) button and the debugger will stop exception a the next exception.
 
-### Why does the style guide list one of my prop types as unknown?
+### Why does the style guide list one of my prop types as `unknown`?
 
 This occurs when you are assigning props via `getDefaultProps` that are not listed within the components `propTypes`.
 

--- a/src/rsg-components/Props/Props.js
+++ b/src/rsg-components/Props/Props.js
@@ -11,8 +11,6 @@ export let Code = ({ className = '', children }) => {
 	return <code className={sMarkdown.code + ' ' + className}>{children}</code>;
 };
 
-export let UnknownPropType = () => <span>unknown</span>;
-
 export function unquote(string) {
 	return trim(string, '"\'');
 }

--- a/src/rsg-components/Props/Props.js
+++ b/src/rsg-components/Props/Props.js
@@ -11,7 +11,7 @@ export let Code = ({ className = '', children }) => {
 	return <code className={sMarkdown.code + ' ' + className}>{children}</code>;
 };
 
-export let UnknownPropType = () => <span>unknown</span>
+export let UnknownPropType = () => <span>unknown</span>;
 
 export function unquote(string) {
 	return trim(string, '"\'');
@@ -39,7 +39,9 @@ export default class Props extends Component {
 	}
 
 	renderType(type) {
-		if (!type) return 'unknown'
+		if (!type) {
+			return 'unknown';
+		}
 
 		let { name } = type;
 
@@ -81,8 +83,11 @@ export default class Props extends Component {
 	}
 
 	renderExtra(prop) {
-		const type = getType(prop)
-		if (!type) return null
+		const type = getType(prop);
+
+		if (!type) {
+			return null;
+		}
 
 		switch (type.name) {
 			case 'enum':

--- a/src/rsg-components/Props/Props.js
+++ b/src/rsg-components/Props/Props.js
@@ -11,6 +11,8 @@ export let Code = ({ className = '', children }) => {
 	return <code className={sMarkdown.code + ' ' + className}>{children}</code>;
 };
 
+export let UnknownPropType = () => <span>unknown</span>
+
 export function unquote(string) {
 	return trim(string, '"\'');
 }
@@ -37,7 +39,10 @@ export default class Props extends Component {
 	}
 
 	renderType(type) {
+		if (!type) return 'unknown'
+
 		let { name } = type;
+
 		switch (name) {
 			case 'arrayOf':
 				return `${type.value.name}[]`;
@@ -76,7 +81,10 @@ export default class Props extends Component {
 	}
 
 	renderExtra(prop) {
-		switch (getType(prop).name) {
+		const type = getType(prop)
+		if (!type) return null
+
+		switch (type.name) {
 			case 'enum':
 				return this.renderEnum(prop);
 			case 'union':

--- a/test/components.props.spec.js
+++ b/test/components.props.spec.js
@@ -115,4 +115,16 @@ describe('Props', () => {
 		);
 	});
 
+	it('should render unknown proptype for a prop when a relevant proptype is not assigned', () => {
+		let result = render([], ['color: "pink"']);
+		expectReactShallow(result).to.contain(
+			<tr>
+				<td><Code>color</Code></td>
+				<td><Code>unknown</Code></td>
+				<td><Code>pink</Code></td>
+				<td><div/></td>
+			</tr>
+		);
+	});
+
 });


### PR DESCRIPTION
Fixes #77.

![image](https://cloud.githubusercontent.com/assets/20490/13456637/18435d62-e09f-11e5-994b-c4769f638545.png)

This ensures that any prop that is assigned via `getDefaultProps` but missing from `propTypes` will be shown as an unknown prop type.

Although this is bad practice in React, I think it's probably best to display the style guide rather than throw and error for this, and ensure that the user can find out the explanation behind unknown proptypes in the styleguide readme.