### PR TITLE
Ensure components list is scrollable

### DIFF
--- a/examples/customised/styleguide/components/Layout/Layout.css
+++ b/examples/customised/styleguide/components/Layout/Layout.css
@@ -19,12 +19,6 @@
 	padding-left: 15px;
 }
 
-.sidebarIsSticky {
-	position: fixed;
-	top: 15px;
-	padding-left: 15px;
-}
-
 .heading {
 	composes: reset font from "../../styles/common.css";
 	margin: 0 0 30px 0;

--- a/examples/customised/styleguide/components/Layout/index.jsx
+++ b/examples/customised/styleguide/components/Layout/index.jsx
@@ -1,5 +1,4 @@
 import { PropTypes } from 'react';
-import Sticky from 'react-sticky';
 
 import s from './Layout.css';
 
@@ -14,11 +13,7 @@ const Renderer = ({ title, components, toc }) => (
 						Generated with <a className={s.link} href="https://github.com/sapegin/react-styleguidist">React Styleguidist</a>
 					</footer>
 				</div>
-				<div className={s.sidebar}>
-					<Sticky className={s.sidebar} stickyClass={s.sidebarIsSticky} topOffset={-15} stickyStyle={{}}>
-						{toc}
-					</Sticky>
-				</div>
+				<div className={s.sidebar}>{toc}</div>
 			</div>
 		</main>
 	</div>

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "prettyjson": "1.1.3",
     "react-codemirror": "0.2.5",
     "react-docgen": "2.7.0",
-    "react-sticky": "3.0.0",
     "semver-utils": "1.1.1",
     "style-loader": "0.13.0",
     "webpack": "1.12.13",

--- a/src/rsg-components/Layout/Layout.css
+++ b/src/rsg-components/Layout/Layout.css
@@ -2,32 +2,29 @@
 	composes: base base-bg from "../../styles/colors.css";
 }
 
-.content {
-	max-width: 1200px;
-	padding: 15px 30px;
-	margin-left: auto;
-	margin-right: auto;
+.wrapper {
+	padding-left: 200px;
 }
 
-.wrapper {
-	display: flex;
+.content {
+	max-width: 1000px;
+	padding: 15px 30px;
 }
 
 .sidebar {
-	position: relative;
+	composes: border from "../../styles/colors.css";
+	border-width: 0 1px 0 0;
+	background: #f5f5f5;
+	position: fixed;
+	top: 0;
+	left: 0;
+	bottom: 0;
 	width: 200px;
-	flex-shrink: 0;
-	padding-left: 15px;
+	overflow: scroll;
 }
 
 .components {
 	overflow: auto; /* to prevent the pane from growing out of the screen */
-}
-
-.sidebarIsSticky {
-	position: fixed;
-	top: 15px;
-	padding-left: 15px;
 }
 
 .heading {

--- a/src/rsg-components/Layout/Layout.css
+++ b/src/rsg-components/Layout/Layout.css
@@ -30,9 +30,13 @@
 
 .heading {
 	composes: reset font from "../../styles/common.css";
-	margin: 0 0 30px 0;
-	font-size: 48px;
+	composes: border from "../../styles/colors.css";
+	border-width: 0 0 1px 0;
+	margin: 0;
+	font-size: 18px;
 	font-weight: normal;
+	display: block;
+	padding: 15px;
 }
 
 .empty {

--- a/src/rsg-components/Layout/Layout.css
+++ b/src/rsg-components/Layout/Layout.css
@@ -9,6 +9,7 @@
 .content {
 	max-width: 1000px;
 	padding: 15px 30px;
+	margin: 0 auto;
 }
 
 .sidebar {

--- a/src/rsg-components/Layout/Renderer.jsx
+++ b/src/rsg-components/Layout/Renderer.jsx
@@ -6,7 +6,6 @@ const Renderer = ({ title, components, toc }) => (
 	<div className={s.root}>
 		<main className={s.wrapper}>
 			<div className={s.content}>
-				<h1 className={s.heading}>{title}</h1>
 				<div className={s.components}>
 					{components}
 					<footer className={s.footer}>
@@ -14,7 +13,10 @@ const Renderer = ({ title, components, toc }) => (
 					</footer>
 				</div>
 			</div>
-			<div className={s.sidebar}>{toc}</div>
+			<div className={s.sidebar}>
+				<h1 className={s.heading}>{title}</h1>
+				{toc}
+			</div>
 		</main>
 	</div>
 );

--- a/src/rsg-components/Layout/Renderer.jsx
+++ b/src/rsg-components/Layout/Renderer.jsx
@@ -1,25 +1,20 @@
 import {PropTypes} from 'react';
-import Sticky from 'react-sticky';
 
 const s = require('./Layout.css');
 
 const Renderer = ({ title, components, toc }) => (
 	<div className={s.root}>
-		<main className={s.content}>
-			<h1 className={s.heading}>{title}</h1>
-			<div className={s.wrapper}>
+		<main className={s.wrapper}>
+			<div className={s.content}>
+				<h1 className={s.heading}>{title}</h1>
 				<div className={s.components}>
 					{components}
 					<footer className={s.footer}>
 						Generated with <a className={s.link} href="https://github.com/sapegin/react-styleguidist">React Styleguidist</a>
 					</footer>
 				</div>
-				<div className={s.sidebar}>
-					<Sticky className={s.sidebar} stickyClass={s.sidebarIsSticky} topOffset={-15} stickyStyle={{}}>
-						{toc}
-					</Sticky>
-				</div>
 			</div>
+			<div className={s.sidebar}>{toc}</div>
 		</main>
 	</div>
 );

--- a/src/rsg-components/TableOfContents/TableOfContents.css
+++ b/src/rsg-components/TableOfContents/TableOfContents.css
@@ -1,6 +1,7 @@
 .root {
 	composes: reset font from "../../styles/common.css";
 	list-style-type: none;
+	padding: 15px 30px;
 }
 
 .item {

--- a/src/rsg-components/TableOfContents/TableOfContents.css
+++ b/src/rsg-components/TableOfContents/TableOfContents.css
@@ -1,7 +1,7 @@
 .root {
 	composes: reset font from "../../styles/common.css";
 	list-style-type: none;
-	padding: 15px 30px;
+	padding: 15px;
 }
 
 .item {


### PR DESCRIPTION
**This PR makes some layout and style changes to the default style guide output**

![styleguidist-scrolling](https://cloud.githubusercontent.com/assets/20490/13458643/6e2f43f8-e0a9-11e5-9896-cb3aea999004.gif)

My existing codebase has a large number of components, running styleguidist on this results in a list of components that is not scrollable do the "sticky" functionality that currently exists.

This PR makes changes to the layout to ensure that the component list is always scrollable. The component list has been moved to the left of the screen due to the fact that there is a max-width on the styleguide(which i think is important) and implementing scrolling functionality with that given layout felt odd. It wasn't clear that you could scroll the components list, this approach goes for something a little more "traditional" as far as documentation styling goes.

![image](https://cloud.githubusercontent.com/assets/20490/13458509/94631bd6-e0a8-11e5-9944-1cfbe5dd0755.png)

