### PR TITLE
Ensures styleguide is always 'style guide' in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/sapegin/react-styleguidist.svg)](https://travis-ci.org/sapegin/react-styleguidist) [![Dependency Status](https://david-dm.org/sapegin/react-styleguidist.svg)](https://david-dm.org/sapegin/react-styleguidist) [![npm](https://img.shields.io/npm/v/react-styleguidist.svg)](https://www.npmjs.com/package/react-styleguidist)
 
-React Styleguidist is a style guide generator for React components. It lists component `propTypes` and shows live, editable usage examples based on Markdown files. You can use it to generate a static HTML page to share and publish or as a workbench for developing new components using hot reloaded dev server. Check out [**the demo styleguide**](http://sapegin.github.io/react-styleguidist/).
+React Styleguidist is a style guide generator for React components. It lists component `propTypes` and shows live, editable usage examples based on Markdown files. You can use it to generate a static HTML page to share and publish or as a workbench for developing new components using hot reloaded dev server. Check out [**the demo style guide**](http://sapegin.github.io/react-styleguidist/).
 
 Based on Webpack, webpack-dev-server and Babel.
 
@@ -28,9 +28,9 @@ Based on Webpack, webpack-dev-server and Babel.
    };
   ```
 
-3. If you use transpilers to run your project files (JSX → JS, SCSS → CSS, etc), you need to set them up for the styleguide too.
+3. If you use transpilers to run your project files (JSX → JS, SCSS → CSS, etc), you need to set them up for the style guide too.
 
-   Styleguidist generates a webpack config that contains all that is needed for the styleguide, but you need to configure the [webpack loaders](https://webpack.github.io/docs/configuration.html#module-loaders) for your project code.
+   Styleguidist generates a webpack config that contains all that is needed for the style guide, but you need to configure the [webpack loaders](https://webpack.github.io/docs/configuration.html#module-loaders) for your project code.
 
    Put the `updateWebpackConfig` function in your `styleguide.config.js`:
 
@@ -91,7 +91,7 @@ Based on Webpack, webpack-dev-server and Babel.
 
 6. Run **`npm run styleguide-server`** to start style guide dev server.
 
-To customize your styleguide, head to the [Configuration section](#configuration) below.
+To customize your style guide, head to the [Configuration section](#configuration) below.
 
 
 ## Documenting components
@@ -386,7 +386,7 @@ export default class Wrapper extends Component {
 
 This occurs when you are assigning props via `getDefaultProps` that are not listed within the components `propTypes`.
 
-For example, the color prop here is assigned via `getDefaultProps` but missing from the `propTypes`, therefore the styleguide is unable to display the correct prop type.
+For example, the color prop here is assigned via `getDefaultProps` but missing from the `propTypes`, therefore the style guide is unable to display the correct prop type.
 
 ```javascript
 Button.propTypes = {


### PR DESCRIPTION
As it says in the PR title. There was a lot of inconsistency in the readme between "style guide" and "styleguide". This ensures that they all use "style guide" where applicable. This does not touch filenames, paths, or options within the readme.