### PR TITLE
Explicitly specify when a prop is required

### DIFF
--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -44,9 +44,6 @@
 	padding-left: 15px;
 }
 
-.optional {
-	composes: light from "../../styles/colors.css";
-}
 .required {
 	composes: light from "../../styles/colors.css";
 }

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -47,6 +47,9 @@
 .optional {
 	composes: light from "../../styles/colors.css";
 }
+.required {
+	composes: light from "../../styles/colors.css";
+}
 .name {
 	composes: name from "../../styles/colors.css";
 }

--- a/src/rsg-components/Props/Props.js
+++ b/src/rsg-components/Props/Props.js
@@ -64,9 +64,7 @@ export default class Props extends Component {
 			);
 		}
 		else {
-			return (
-				<span className={s.optional}>Optional</span>
-			);
+			return '';
 		}
 	}
 

--- a/src/rsg-components/Props/Props.js
+++ b/src/rsg-components/Props/Props.js
@@ -54,7 +54,9 @@ export default class Props extends Component {
 
 	renderDefault(prop) {
 		if (prop.required) {
-			return '';
+			return (
+				<span className={s.required}>Required</span>
+			);
 		}
 		else if (prop.defaultValue) {
 			return (

--- a/test/components.props.spec.js
+++ b/test/components.props.spec.js
@@ -28,7 +28,7 @@ describe('Props', () => {
 			<tr>
 				<td><Code>color</Code></td>
 				<td><Code>string</Code></td>
-				<td><span>Optional</span></td>
+				<td></td>
 				<td><div/></td>
 			</tr>
 		);
@@ -64,7 +64,7 @@ describe('Props', () => {
 			<tr>
 				<td><Code>colors</Code></td>
 				<td><Code>string[]</Code></td>
-				<td><span>Optional</span></td>
+				<td></td>
 				<td><div/></td>
 			</tr>
 		);
@@ -76,7 +76,7 @@ describe('Props', () => {
 			<tr>
 				<td><Code>num</Code></td>
 				<td><Code>Number</Code></td>
-				<td><span>Optional</span></td>
+				<td></td>
 				<td><div/></td>
 			</tr>
 		);
@@ -88,14 +88,14 @@ describe('Props', () => {
 			<tr>
 				<td><Code>foo</Code></td>
 				<td><Code>shape</Code></td>
-				<td><span>Optional</span></td>
+				<td></td>
 				<td>
 					<div>
 						<div>
-							<Code>bar</Code>: <Code>number</Code>
+							<Code>bar</Code>: <Code>number</Code> — <span>Required</span>
 						</div>
 						<div>
-							<Code>baz</Code>: <Code>any</Code> — <span>Optional</span>
+							<Code>baz</Code>: <Code>any</Code>
 						</div>
 					</div>
 				</td>
@@ -109,7 +109,7 @@ describe('Props', () => {
 			<tr>
 				<td><Code>color</Code></td>
 				<td><Code>string</Code></td>
-				<td><span>Optional</span></td>
+				<td></td>
 				<td><div><Markdown text="Label"/></div></td>
 			</tr>
 		);

--- a/test/components.props.spec.js
+++ b/test/components.props.spec.js
@@ -52,7 +52,7 @@ describe('Props', () => {
 			<tr>
 				<td><Code>color</Code></td>
 				<td><Code>string</Code></td>
-				<td></td>
+				<td><span>Required</span></td>
 				<td><div/></td>
 			</tr>
 		);


### PR DESCRIPTION
Maybe this is just a nitpick from my side, but I think it would be better to explicitly specify it when a prop is required. This way a developer does not overlook your prop requirement that easy.

I'm curious what you think about this change :smile:.