### PR TITLE
Support for creating Sections

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -154,7 +154,7 @@ You *can* use `React.createClass` in your code examples, but if you need a more 
 You can change some settings in the `styleguide.config.js` file in your projectâ€™s root folder.
 
 * **`components`**<br>
-  Type: `String` or `Function`, required<br>
+  Type: `String` or `Function`, required unless `sections` is provided<br>
   - when `String`: a [glob pattern](https://github.com/isaacs/node-glob#glob-primer) that matches all your component modules. Relative to config folder.
   - when `Function`: a function that returns an array of module paths.
 
@@ -177,6 +177,28 @@ You can change some settings in the `styleguide.config.js` file in your projectâ
       });
     }
   };
+  ```
+
+* **`sections`**<br>
+  Type: `Array`
+
+  Allows components to be grouped into sections with a title and optional overview content. Sections
+  can also be content only, with no associated components (for example, a textual introduction). A section
+  definition consists of:<br>
+  - `name` - the title of the section.
+  - `content` (optional) - location of a Markdown file containing the overview content.
+  - `components` (optional) - a string or function providing a list of components. The same rules apply as for the root `components` option.
+
+  Configuring a guide with a textual introduction section, then a UI section would look like:
+
+  ```javascript
+  module.exports = {
+    // ...
+    sections: [
+      {name: 'Introduction', content: 'docs/introduction.md'},
+      {name: 'UI Components', content: 'docs/ui.md', components: 'lib/components/ui/*.js'}
+    ]
+  }
   ```
 
 * **`skipComponentsWithoutExample`**<br>

--- a/src/index.js
+++ b/src/index.js
@@ -13,9 +13,25 @@ if (module.hot) {
 }
 
 // Load style guide
-let { config, components } = require('styleguide!');
+let { config, components, sections } = require('styleguide!');
 
-components = setComponentsNames(components);
-globalizeComponents(components);
+function processComponents(cs) {
+	cs = setComponentsNames(cs);
+	globalizeComponents(cs);
 
-ReactDOM.render(<StyleGuide config={config} components={components}/>, document.getElementById('app'));
+	return cs;
+}
+
+function processSections(ss) {
+	return ss.map(section => {
+		section.components = processComponents(section.components || []);
+		section.sections = processSections(section.sections || []);
+
+		return section;
+	});
+}
+
+components = processComponents(components);
+sections = processSections(sections);
+
+ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -1,20 +1,26 @@
 import { Component, PropTypes } from 'react';
 import ReactComponent from 'rsg-components/ReactComponent';
 import Renderer from 'rsg-components/ReactComponent/Renderer';
+import Section from 'rsg-components/Section';
+import SRenderer from 'rsg-components/Section/Renderer';
 
 export default class Components extends Component {
 	static propTypes = {
 		highlightTheme: PropTypes.string.isRequired,
-		components: PropTypes.array.isRequired
+		components: PropTypes.array.isRequired,
+		sections: PropTypes.array.isRequired
 	};
 
 	renderComponents() {
-		const { highlightTheme, components } = this.props;
+		const { highlightTheme, components, sections } = this.props;
 		const ComponentRenderer = ReactComponent(Renderer);
+		const SectionRenderer = Section(SRenderer);
 
 		return components.map((component) => {
 			return (<ComponentRenderer key={component.name} highlightTheme={highlightTheme} component={component} />);
-		});
+		}).concat(sections.map((section) => {
+			return (<SectionRenderer key={section.name} highlightTheme={highlightTheme} section={section} />);
+		}));
 	}
 
 	render() {

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -1,8 +1,7 @@
 import { Component, PropTypes } from 'react';
 import ReactComponent from 'rsg-components/ReactComponent';
 import Renderer from 'rsg-components/ReactComponent/Renderer';
-import Section from 'rsg-components/Section';
-import SRenderer from 'rsg-components/Section/Renderer';
+import Sections from 'rsg-components/Sections';
 
 export default class Components extends Component {
 	static propTypes = {
@@ -12,21 +11,27 @@ export default class Components extends Component {
 	};
 
 	renderComponents() {
-		const { highlightTheme, components, sections } = this.props;
+		const { highlightTheme, components } = this.props;
 		const ComponentRenderer = ReactComponent(Renderer);
-		const SectionRenderer = Section(SRenderer);
 
 		return components.map((component) => {
 			return (<ComponentRenderer key={component.name} highlightTheme={highlightTheme} component={component} />);
-		}).concat(sections.map((section) => {
-			return (<SectionRenderer key={section.name} highlightTheme={highlightTheme} section={section} />);
-		}));
+		});
+	}
+
+	renderSections() {
+		const { highlightTheme, sections } = this.props;
+
+		return (
+			<Sections highlightTheme={highlightTheme} sections={sections} />
+		);
 	}
 
 	render() {
 		return (
 			<div>
 				{this.renderComponents()}
+				{this.renderSections()}
 			</div>
 		);
 	}

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -4,16 +4,19 @@ import TableOfContents from 'rsg-components/TableOfContents';
 
 import s from './Layout.css';
 
+import _ from 'lodash';
+
 const Layout = (Renderer) => class extends Component {
 	static propTypes = {
 		config: PropTypes.object.isRequired,
-		components: PropTypes.array.isRequired
+		components: PropTypes.array.isRequired,
+		sections: PropTypes.array.isRequired
 	};
 
-	renderComponents(config, components) {
-		if (components.length) {
+	renderComponents(config, components, sections) {
+		if (!_.isEmpty(components) || !_.isEmpty(sections)) {
 			return (
-				<Components highlightTheme={config.highlightTheme} components={components}/>
+				<Components highlightTheme={config.highlightTheme} components={components} sections={sections} />
 			);
 		}
 		else {
@@ -26,18 +29,19 @@ const Layout = (Renderer) => class extends Component {
 		}
 	}
 
-	renderTableOfContents(components) {
-		return <TableOfContents components={components}/>;
+	renderTableOfContents(components, sections) {
+		return <TableOfContents components={components} sections={sections} />;
 	}
 
 	render() {
-		let { config, components } = this.props;
+		let { config, components, sections } = this.props;
 
 		return (
 			<Renderer
 				title={config.title}
-				components={this.renderComponents(config, components)}
-				toc={this.renderTableOfContents(components)}
+				components={this.renderComponents(config, components, sections)}
+				sections={this.props.sections}
+				toc={this.renderTableOfContents(components, sections)}
 			/>
 		);
 	}

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -4,7 +4,7 @@ import TableOfContents from 'rsg-components/TableOfContents';
 
 import s from './Layout.css';
 
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 const Layout = (Renderer) => class extends Component {
 	static propTypes = {
@@ -14,7 +14,7 @@ const Layout = (Renderer) => class extends Component {
 	};
 
 	renderComponents(config, components, sections) {
-		if (!_.isEmpty(components) || !_.isEmpty(sections)) {
+		if (!isEmpty(components) || !isEmpty(sections)) {
 			return (
 				<Components highlightTheme={config.highlightTheme} components={components} sections={sections} />
 			);

--- a/src/rsg-components/Section/Renderer.jsx
+++ b/src/rsg-components/Section/Renderer.jsx
@@ -1,0 +1,31 @@
+import {PropTypes} from 'react';
+
+const s = require('./Section.css');
+
+const Renderer = ({ name, content, components}) => {
+  return (
+    <div className={s.root}>
+      <header className={s.header}>
+        <h1 className={s.heading} id={name}>
+          <a className={s.anchor} href={'#' + name}></a>
+          {name}
+        </h1>
+      </header>
+      <div>
+        {content}
+      </div>
+      <div>
+        {components}
+      </div>
+    </div>
+  );
+};
+
+Renderer.propTypes = {
+  name: PropTypes.string.isRequired,
+  content: PropTypes.array,
+  components: PropTypes.object
+};
+
+
+export default Renderer;

--- a/src/rsg-components/Section/Section.css
+++ b/src/rsg-components/Section/Section.css
@@ -1,0 +1,16 @@
+.root {
+  margin-bottom: 50px;
+  font-size: 16px;
+}
+
+.header {
+
+}
+
+.heading {
+
+}
+
+.anchor {
+  
+}

--- a/src/rsg-components/Section/Section.js
+++ b/src/rsg-components/Section/Section.js
@@ -1,0 +1,65 @@
+import React, { Component, PropTypes } from 'react';
+import Markdown from 'rsg-components/Markdown';
+import Playground from 'rsg-components/Playground';
+import Components from 'rsg-components/Components';
+
+const Section = (Renderer) => class extends Component {
+	static propTypes = {
+		highlightTheme: PropTypes.string.isRequired,
+		section: PropTypes.object.isRequired
+	};
+
+	renderContent(highlightTheme, examples) {
+		if (!examples) {
+			return null;
+		}
+
+		return examples.map((example, index) => {
+			switch (example.type) {
+				case 'code':
+					return (
+						<Playground
+							code={example.content}
+							evalInContext={example.evalInContext}
+							highlightTheme={highlightTheme}
+							key={index}
+						/>
+					);
+				case 'markdown':
+					return (
+						<Markdown
+							text={example.content}
+							key={index}
+						/>
+					);
+			}
+		});
+	}
+
+	renderComponents(highlightTheme, components, sections) {
+		if (!components && !sections) {
+			return null;
+		}
+
+		return (
+			<Components highlightTheme={highlightTheme}
+				components={components || []}
+				sections={sections || []}
+			/>
+		);
+	}
+
+	render() {
+		const {highlightTheme, section} = this.props;
+
+		return (
+			<Renderer
+				name={section.name}
+				content={this.renderContent(highlightTheme, section.content)}
+				components={this.renderComponents(highlightTheme, section.components, section.sections)}
+			/>
+		);
+	}
+};
+
+export default Section;

--- a/src/rsg-components/Section/index.js
+++ b/src/rsg-components/Section/index.js
@@ -1,0 +1,1 @@
+export { default } from './Section.js';

--- a/src/rsg-components/Sections/Sections.js
+++ b/src/rsg-components/Sections/Sections.js
@@ -1,0 +1,27 @@
+import { Component, PropTypes } from 'react';
+import Section from 'rsg-components/Section';
+import Renderer from 'rsg-components/Section/Renderer';
+
+export default class Sections extends Component {
+	static propTypes = {
+		highlightTheme: PropTypes.string.isRequired,
+		sections: PropTypes.array.isRequired
+	};
+
+	renderSections() {
+		const { highlightTheme, sections } = this.props;
+		const SectionRenderer = Section(Renderer);
+
+		return sections.map((section) => {
+			return (<SectionRenderer key={section.name} highlightTheme={highlightTheme} section={section} />);
+		});
+	}
+
+	render() {
+		return (
+			<div>
+				{this.renderSections()}
+			</div>
+		);
+	}
+}

--- a/src/rsg-components/Sections/index.js
+++ b/src/rsg-components/Sections/index.js
@@ -1,0 +1,1 @@
+export { default } from './Sections.js';

--- a/src/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/rsg-components/TableOfContents/TableOfContents.js
@@ -11,15 +11,34 @@ class TableOfContents extends Component {
 		};
 	}
 
-	render() {
-		let { searchTerm } = this.state;
-		let { components } = this.props;
-
-		searchTerm = searchTerm.trim();
+	renderLevel(components, sections, searchTerm) {
 		if (searchTerm !== '') {
 			let regExp = new RegExp(searchTerm.split('').join('.*'), 'gi');
 			components = components.filter(component => component.name.match(regExp));
 		}
+
+		return (
+			<ul className={s.list}>
+				{(components || []).map(({ name }) => (
+					<li className={s.item} key={name}>
+						<a className={s.link} href={'#' + name}>{name}</a>
+					</li>
+				))}
+				{(sections || []).map(({ name, components: subComponents, sections: subSections }) => (
+					<li key={name}>
+						<a className={s.section} href={'#' + name}>{name}</a>
+						{this.renderLevel(subComponents, subSections, searchTerm)}
+					</li>
+				))}
+			</ul>
+		);
+	}
+
+	render() {
+		let { searchTerm } = this.state;
+		let { components, sections } = this.props;
+
+		searchTerm = searchTerm.trim();
 
 		return (
 			<div className={s.root}>
@@ -29,20 +48,15 @@ class TableOfContents extends Component {
 					onChange={(e) => this.setState({ searchTerm: e.target.value })}
 					value={searchTerm}
 				/>
-				<ul className={s.list}>
-					{components.map(({ name }) => (
-						<li className={s.item} key={name}>
-							<a className={s.link} href={'#' + name}>{name}</a>
-						</li>
-					))}
-				</ul>
+				{this.renderLevel(components, sections, searchTerm)}
 			</div>
 		);
 	}
 }
 
 TableOfContents.propTypes = {
-	components: PropTypes.array.isRequired
+	components: PropTypes.array.isRequired,
+	sections: PropTypes.array.isRequired
 };
 
 export default TableOfContents;

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -10,6 +10,7 @@ var utils = require('./server');
 var CONFIG_FILENAME = 'styleguide.config.js';
 var DEFAULT_CONFIG = {
 	components: null,
+	sections: null,
 	skipComponentsWithoutExample: false,
 	title: 'Style guide',
 	styleguideDir: 'styleguide',
@@ -123,8 +124,11 @@ function findConfig(argv) {
  * @param {Object} options Config options.
  */
 function validateConfig(options) {
-	if (!options.components) {
-		throw Error('Styleguidist: "components" option is required.');
+	if (!options.components && !options.sections) {
+		throw Error('Styleguidist: "components" or "sections" option is required.');
+	}
+	if (options.sections && !_.isArray(options.sections)) {
+		throw Error('Styleguidist: "sections" option must be an array.');
 	}
 	if (options.getExampleFilename && typeof options.getExampleFilename !== 'function') {
 		throw Error('Styleguidist: "getExampleFilename" option must be a function.');


### PR DESCRIPTION
This PR introduces the ability to split components into sections. Sections are configured in the `styleguide.config.js` file as a peer to the main `components` property. Sections can be nested if desired, since they are processed recursively. Sections can also include a reference to a `content` examples file that is used an introduction to the section.

Support for non-sectioned components is retained, so this PR should have no effect on existing guides that don't configure sections.