### PR TITLE
Example Doclets

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,6 +115,22 @@ Styleguidist generates documentation from 2 sources:
   Any [Markdown](http://daringfireball.net/projects/markdown/) is **allowed** _here_.
   ```
 
+* **Loading examples using doclet tags**
+
+  Additional example files can be specifically associated with components using doclet (`@example`) syntax.
+  The following component will also have an example as loaded from the `extra.examples.md` file.
+
+  ```js
+  /**
+   * Component is described here.
+   *
+   * @example ./extra.examples.md
+   */
+  export default class SomeComponent extends React.Component {
+    // ...
+  }
+  ```
+
 ### Writing code examples
 
 Code examples in Markdown use the ES6+JSX syntax. They can access all the components listed, they are exposed as global variables.

--- a/loaders/props.loader.js
+++ b/loaders/props.loader.js
@@ -1,24 +1,43 @@
 var path = require('path');
 var reactDocs = require('react-docgen');
+var _ = require('lodash');
+
+var requirePlaceholder = '<%{#require#}%>';
 
 module.exports = function (source) {
 	this.cacheable && this.cacheable();
 
-	var props;
+	var jsonProps;
 	try {
-		props = reactDocs.parse(source);
+		var props = reactDocs.parse(source);
+
+		if (props.description) {
+			props.doclets = reactDocs.utils.docblock.getDoclets(props.description);
+			props.description = props.description.replace(/^@(\w+)(?:$|\s((?:[^](?!^@\w))*))/gmi, '');
+		} else {
+			props.doclets = {};
+		}
+
+		if (props.doclets.example) {
+			props.example = requirePlaceholder;
+		}
+
+		jsonProps = JSON.stringify(props).replace(
+			'"' + requirePlaceholder + '"', 
+			props.doclets.example && 'require(' + JSON.stringify('examples!' + props.doclets.example) + ')'
+		);
 	}
 	catch (e) {
 		console.log('Error when parsing', path.basename(this.request));
 		console.log(e.toString());
 		console.log();
-		props = {};
+		jsonProps = null;
 	}
 
 	return [
 		'if (module.hot) {',
 		'	module.hot.accept([]);',
 		'}',
-		'module.exports = ' + JSON.stringify(props)
+		'module.exports = ' + jsonProps + ';'
 	].join('\n');
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { setComponentsNames, globalizeComponents } from './utils/utils';
+import { setComponentsNames, globalizeComponents, promoteInlineExamples } from './utils/utils';
 import StyleGuide from 'rsg-components/StyleGuide';
 
 import 'highlight.js/styles/tomorrow.css';
@@ -15,6 +15,7 @@ if (module.hot) {
 // Load style guide
 let { config, components } = require('styleguide!');
 
+components = promoteInlineExamples(components);
 components = setComponentsNames(components);
 globalizeComponents(components);
 

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -16,3 +16,12 @@ export function globalizeComponents(components) {
 		global[component.name] = component.module.default || component.module;
 	});
 }
+
+export function promoteInlineExamples(components) {
+	components.map(c => {
+		if (c.props.example) {
+			c.examples = (c.examples || []).concat(c.props.example);
+		}
+	});
+	return components;
+}


### PR DESCRIPTION
This PR introduces the ability to associate additional example files using doclet tags in the description.

For example, a component defined like the below will have the examples in `extra.examples.md` associated with it:

  ```js
  /**
   * Component is described here.
   *
   * @example ./extra.examples.md
   */
  export default class SomeComponent extends React.Component {
    // ...
  }