### PR TITLE
Ensure lack of sections does not break styleguide and update examples

### DIFF
--- a/examples/basic-sections/Readme.md
+++ b/examples/basic-sections/Readme.md
@@ -1,0 +1,8 @@
+To start example style guide:
+
+```
+npm install
+npm start
+```
+
+Then open [http://localhost:3000](http://localhost:3000) in your browser.

--- a/examples/basic-sections/lib/components/Button/Button.css
+++ b/examples/basic-sections/lib/components/Button/Button.css
@@ -1,0 +1,10 @@
+.root {
+	padding: .5em 1.5em;
+	color: #666;
+	background-color: #fff;
+	border: 1px solid currentColor;
+	border-radius: .3em;
+	text-align: center;
+	vertical-align: middle;
+	cursor: pointer;
+}

--- a/examples/basic-sections/lib/components/Button/Button.js
+++ b/examples/basic-sections/lib/components/Button/Button.js
@@ -1,0 +1,38 @@
+import { Component, PropTypes } from 'react';
+
+import s from './Button.css';
+
+/**
+ * The only true button.
+ */
+export default function Button({
+	color,
+	size,
+	children
+}) {
+	let styles = {
+		color: color,
+		fontSize: Button.sizes[size]
+	};
+
+	return (
+		<button className={s.root} style={styles}>{children}</button>
+	);
+}
+Button.propTypes = {
+	/**
+	 * Button label.
+	 */
+	children: PropTypes.string.isRequired,
+	color: PropTypes.string,
+	size: PropTypes.oneOf(['small', 'normal', 'large']),
+};
+Button.defaultProps = {
+	color: '#333',
+	size: 'normal'
+};
+Button.sizes = {
+	small: '10px',
+	normal: '14px',
+	large: '18px'
+};

--- a/examples/basic-sections/lib/components/Button/Readme.md
+++ b/examples/basic-sections/lib/components/Button/Readme.md
@@ -1,0 +1,15 @@
+Basic button:
+
+	<Button>Push Me</Button>
+
+Big pink button:
+
+	<Button size="large" color="deeppink">Lick Me</Button>
+
+And you *can* **use** `any` [Markdown](http://daringfireball.net/projects/markdown/) here.
+
+If you define a fenced code block with a language flag it will be rendered as a regular Markdown code snippet:
+
+```javascript
+import React from 'react';
+```

--- a/examples/basic-sections/lib/components/Button/index.js
+++ b/examples/basic-sections/lib/components/Button/index.js
@@ -1,0 +1,1 @@
+export { default } from './Button.js';

--- a/examples/basic-sections/lib/components/Modal/Modal.js
+++ b/examples/basic-sections/lib/components/Modal/Modal.js
@@ -1,0 +1,24 @@
+import { Component, PropTypes } from 'react';
+import ReactModal from 'react-modal';
+
+/**
+ * Modal dialog (actually just a [react-modal](https://github.com/rackt/react-modal) wrapper).
+ */
+export default class Modal extends Component {
+	static propTypes = {
+		isOpen: PropTypes.bool,
+		children: PropTypes.node.isRequired
+	};
+
+	render() {
+		let { isOpen, children } = this.props;
+		let style = {
+			overlay: {
+				zIndex: 999
+			}
+		};
+		return (
+			<ReactModal isOpen={isOpen} style={style}>{children}</ReactModal>
+		);
+	}
+}

--- a/examples/basic-sections/lib/components/Modal/Readme.md
+++ b/examples/basic-sections/lib/components/Modal/Readme.md
@@ -1,0 +1,14 @@
+Each example has its own state that you can access at the `state` variable and change with the `setState` function. Default state is `{}`.
+
+	<div>
+		<button onClick={() => setState({isOpen: true})}>Open</button>
+		<Modal isOpen={state.isOpen}>
+        	<h1>Hallo!</h1>
+        	<button onClick={() => setState({isOpen: false})}>Close</button>
+        </Modal>
+	</div>
+
+If you want to set the default state you can do something like that:
+
+	'count' in state || setState({count: 1});
+    <button onClick={() => setState({count: state.count+1})}>{state.count}</button>

--- a/examples/basic-sections/lib/components/Modal/index.js
+++ b/examples/basic-sections/lib/components/Modal/index.js
@@ -1,0 +1,1 @@
+export { default } from './Modal.js';

--- a/examples/basic-sections/lib/components/Placeholder/Placeholder.css
+++ b/examples/basic-sections/lib/components/Placeholder/Placeholder.css
@@ -1,0 +1,3 @@
+.root {
+	background: #ccc;
+}

--- a/examples/basic-sections/lib/components/Placeholder/Placeholder.js
+++ b/examples/basic-sections/lib/components/Placeholder/Placeholder.js
@@ -1,0 +1,43 @@
+import { Component, PropTypes } from 'react';
+
+import s from './Placeholder.css';
+
+/**
+ * Image placeholders.
+ */
+export default class Placeholder extends Component {
+	static propTypes = {
+		type: PropTypes.oneOf(['animal', 'bacon', 'beard', 'bear', 'cat', 'food', 'city', 'nature', 'people']),
+		width: PropTypes.number,
+		height: PropTypes.number
+	};
+
+	static defaultProps = {
+		type: 'animal',
+		width: 150,
+		height: 150
+	};
+
+	getImageUrl() {
+		let { type, width, height } = this.props;
+		let types = {
+			animal: `http://placeimg.com/${width}/${height}/animals`,
+			bacon: `http://baconmockup.com/${width}/${height}`,
+			bear: `http://www.placebear.com/${width}/${height}`,
+			beard: `http://placebeard.it/${width}/${height}`,
+			cat: `http://lorempixel.com/${width}/${height}/cats`,
+			city: `http://lorempixel.com/${width}/${height}/city`,
+			food: `http://lorempixel.com/${width}/${height}/food`,
+			nature: `http://lorempixel.com/${width}/${height}/nature`,
+			people: `http://lorempixel.com/${width}/${height}/people`,
+		};
+		return types[type];
+	}
+
+	render() {
+		let { width, height } = this.props;
+		return (
+			<img className={s.root} src={this.getImageUrl()} width={width} height={height}/>
+		);
+	}
+}

--- a/examples/basic-sections/lib/components/Placeholder/Readme.md
+++ b/examples/basic-sections/lib/components/Placeholder/Readme.md
@@ -1,0 +1,1 @@
+	<Placeholder type="beard"/>

--- a/examples/basic-sections/lib/components/Placeholder/index.js
+++ b/examples/basic-sections/lib/components/Placeholder/index.js
@@ -1,0 +1,1 @@
+export { default } from './Placeholder.js';

--- a/examples/basic-sections/lib/components/RandomButton/RandomButton.css
+++ b/examples/basic-sections/lib/components/RandomButton/RandomButton.css
@@ -1,0 +1,12 @@
+.root {
+	padding: .5em 1.5em;
+	color: #666;
+	background-color: #fff;
+	border: 1px solid currentColor;
+	border-radius: .3em;
+	font-size: 16px;
+	font-weight: bold;
+	text-align: center;
+	vertical-align: middle;
+	cursor: pointer;
+}

--- a/examples/basic-sections/lib/components/RandomButton/RandomButton.js
+++ b/examples/basic-sections/lib/components/RandomButton/RandomButton.js
@@ -1,0 +1,35 @@
+import { Component, PropTypes } from 'react';
+import sample from 'lodash/sample';
+
+import s from './RandomButton.css';
+
+/**
+ * Button that changes label on every click.
+ */
+export default class RandomButton extends Component {
+	static propTypes = {
+		/**
+		 * List of possible labels.
+		 */
+		variants: PropTypes.array.isRequired
+	};
+
+	constructor(props) {
+		super();
+		this.state = {
+			label: sample(props.variants)
+		};
+	}
+
+	handleClick() {
+		this.setState({
+			label: sample(this.props.variants)
+		});
+	}
+
+	render() {
+		return (
+			<button className={s.root} onClick={this.handleClick.bind(this)}>{this.state.label}</button>
+		);
+	}
+}

--- a/examples/basic-sections/lib/components/RandomButton/Readme.md
+++ b/examples/basic-sections/lib/components/RandomButton/Readme.md
@@ -1,0 +1,4 @@
+You can `require` external files in your examples:
+
+	const names = require('dog-names').all;
+	<RandomButton variants={names}/>

--- a/examples/basic-sections/lib/components/RandomButton/index.js
+++ b/examples/basic-sections/lib/components/RandomButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './RandomButton.js';

--- a/examples/basic-sections/styleguide.config.js
+++ b/examples/basic-sections/styleguide.config.js
@@ -1,0 +1,37 @@
+var path = require('path');
+var glob = require('glob');
+
+module.exports = {
+	title: 'React Style Guide Example',
+	sections: [
+		{
+			name: 'Example Section',
+			components: function() {
+				return glob.sync(path.resolve(__dirname, 'lib/components/**/*.js'))
+			 .filter(function(module) {
+					return /\/[A-Z]\w*\.js$/.test(module);
+				})
+			}
+		}
+	],
+	updateWebpackConfig: function(webpackConfig, env) {
+		webpackConfig.module.loaders.push(
+			{
+				test: /\.jsx?$/,
+				include: __dirname,
+				loader: 'babel'
+			},
+			{
+				test: /\.css$/,
+				include: __dirname,
+				loader: 'style!css?modules&importLoaders=1'
+			},
+			{
+				test: /\.json$/,
+				include: path.dirname(require.resolve('dog-names/package.json')),
+				loader: 'json'
+			}
+		);
+		return webpackConfig;
+	}
+};

--- a/examples/basic-sections/styleguide/CNAME
+++ b/examples/basic-sections/styleguide/CNAME
@@ -1,0 +1,1 @@
+react-styleguidist.js.org

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "mocha:watch": "cross-env NODE_ENV=test mocha --watch --reporter min test",
     "start": "./bin/styleguidist server --config examples/basic/styleguide.config.js",
     "start:customised": "./bin/styleguidist server --config examples/customised/styleguide.config.js",
+    "start:sections": "./bin/styleguidist server --config examples/basic-sections/styleguide.config.js",
     "lint": "eslint src --ext .js",
     "build": "./bin/styleguidist build --config examples/basic/styleguide.config.js",
     "build:customised": "./bin/styleguidist build --config examples/customised/styleguide.config.js",

--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,15 @@ function processSections(ss) {
 	});
 }
 
-components = processComponents(components);
-sections = processSections(sections);
+// Components are required unless sections are provided
+if (sections) {
+	sections = processSections(sections)
+	components = []
+} else {
+	components = processComponents(components)
+	sections = []
+}
+components = components ? processComponents(components) : [];
+sections = sections ? processSections(sections) : [];
 
 ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));

--- a/src/index.js
+++ b/src/index.js
@@ -35,13 +35,12 @@ function processSections(ss) {
 
 // Components are required unless sections are provided
 if (sections) {
-	sections = processSections(sections)
-	components = []
-} else {
-	components = processComponents(components)
-	sections = []
+	sections = processSections(sections);
+	components = [];
 }
-components = components ? processComponents(components) : [];
-sections = sections ? processSections(sections) : [];
+else {
+	components = processComponents(components);
+	sections = [];
+}
 
 ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));

--- a/src/index.js
+++ b/src/index.js
@@ -33,14 +33,7 @@ function processSections(ss) {
 	});
 }
 
-// Components are required unless sections are provided
-if (sections) {
-	sections = processSections(sections);
-	components = [];
-}
-else {
-	components = processComponents(components);
-	sections = [];
-}
+components = processComponents(components);
+sections = processSections(sections || []);
 
 ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));


### PR DESCRIPTION
This fixes issues introduced by the merge of #108 in to master.

Both @paulj and @sapegin may have some ideas on the changes to `index.js` here, but this ensures that sections not being provided will not break the styleguide. There were issues with running examples as a result of this merge.

This also adds a basic example using sections for testing this new feature.