### PR TITLE
Add basic styling for section headings

### DIFF
--- a/src/rsg-components/Section/Section.css
+++ b/src/rsg-components/Section/Section.css
@@ -4,13 +4,18 @@
 }
 
 .header {
-
+	composes: font from "../../styles/common.css";
+	margin-bottom: 20px;
+	font-weight: bold;
 }
 
 .heading {
-
+	position: relative;
+	margin: 0 0 6px 0;
+	font-size: 38px;
+	font-weight: bold;
 }
 
 .anchor {
-  
+
 }

--- a/src/rsg-components/Section/Section.css
+++ b/src/rsg-components/Section/Section.css
@@ -10,7 +10,6 @@
 }
 
 .heading {
-	position: relative;
 	margin: 0 0 6px 0;
 	font-size: 38px;
 	font-weight: bold;


### PR DESCRIPTION
Takes some styling from the existing ReactComponent headings and ensures that sections do not use Times New Roman and look out of place.

![image](https://cloud.githubusercontent.com/assets/20490/14417367/e3acf8bc-ffe6-11e5-8bef-d991d57e7a26.png)
