### PR TITLE
Single Component View

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-runtime": "6.5.0",
     "babel-standalone": "6.4.4",
     "chalk": "1.1.1",
-    "classnames": "2.2.3",
+    "classnames": "^2.2.3",
     "codemirror": "5.11.0",
     "css-loader": "0.23.1",
     "entities": "~1.1.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import filter from 'lodash/filter';
 import ReactDOM from 'react-dom';
 import { setComponentsNames, globalizeComponents, promoteInlineExamples, flattenChildren } from './utils/utils';
 import StyleGuide from 'rsg-components/StyleGuide';
@@ -36,4 +37,13 @@ function processSections(ss) {
 components = processComponents(components);
 sections = processSections(sections || []);
 
-ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+if (window.location.hash.substr(0, 3) === '#!/') {
+	const targetComponentName = window.location.hash.substr(3);
+	const filteredComponents = filter(components, function (component) {
+		return component.name === targetComponentName
+	})
+	ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} />, document.getElementById('app'));
+} else {
+	ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ components = processComponents(components);
 sections = processSections(sections || []);
 
 
+let hasRenderedFullStyleguide = false;
 function renderStyleguide() {
 	if (window.location.hash.substr(0, 3) === '#!/') {
 		const targetComponentName = window.location.hash.substr(3);
@@ -55,9 +56,13 @@ function renderStyleguide() {
 		});
 
 		ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} sidebar={false} />, document.getElementById('app'));
+		hasRenderedFullStyleguide = false;
 	}
 	else {
-		ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+		if (!hasRenderedFullStyleguide) {
+			ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+			hasRenderedFullStyleguide = true;
+		}
 	}
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,21 +39,26 @@ function processSections(ss) {
 components = processComponents(components);
 sections = processSections(sections || []);
 
-if (window.location.hash.substr(0, 3) === '#!/') {
-	const targetComponentName = window.location.hash.substr(3);
 
-	const filteredComponents = filter(components, function (component) {
-		return component.name === targetComponentName
-	})
+function renderStyleguide () {
+	if (window.location.hash.substr(0, 3) === '#!/') {
+		const targetComponentName = window.location.hash.substr(3);
 
-	forEach(sections, function (section) {
-		merge(filteredComponents, filter(section.components, function (component) {
+		const filteredComponents = filter(components, function (component) {
 			return component.name === targetComponentName
-		}))
-	})
+		})
 
-	ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} sidebar={false} />, document.getElementById('app'));
-} else {
-	ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+		forEach(sections, function (section) {
+			merge(filteredComponents, filter(section.components, function (component) {
+				return component.name === targetComponentName
+			}))
+		})
+
+		ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} sidebar={false} />, document.getElementById('app'));
+	} else {
+		ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
+	}
 }
 
+window.addEventListener("hashchange", renderStyleguide);
+renderStyleguide();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import merge from 'lodash/merge'
 import filter from 'lodash/filter';
+import forEach from 'lodash/forEach';
 import ReactDOM from 'react-dom';
 import { setComponentsNames, globalizeComponents, promoteInlineExamples, flattenChildren } from './utils/utils';
 import StyleGuide from 'rsg-components/StyleGuide';
@@ -39,10 +41,18 @@ sections = processSections(sections || []);
 
 if (window.location.hash.substr(0, 3) === '#!/') {
 	const targetComponentName = window.location.hash.substr(3);
+
 	const filteredComponents = filter(components, function (component) {
 		return component.name === targetComponentName
 	})
-	ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} />, document.getElementById('app'));
+
+	forEach(sections, function (section) {
+		merge(filteredComponents, filter(section.components, function (component) {
+			return component.name === targetComponentName
+		}))
+	})
+
+	ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} sidebar={false} />, document.getElementById('app'));
 } else {
 	ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import merge from 'lodash/merge'
+import merge from 'lodash/merge';
 import filter from 'lodash/filter';
 import forEach from 'lodash/forEach';
 import ReactDOM from 'react-dom';
@@ -40,25 +40,26 @@ components = processComponents(components);
 sections = processSections(sections || []);
 
 
-function renderStyleguide () {
+function renderStyleguide() {
 	if (window.location.hash.substr(0, 3) === '#!/') {
 		const targetComponentName = window.location.hash.substr(3);
 
-		const filteredComponents = filter(components, function (component) {
-			return component.name === targetComponentName
-		})
+		const filteredComponents = filter(components, function(component) {
+			return component.name === targetComponentName;
+		});
 
-		forEach(sections, function (section) {
-			merge(filteredComponents, filter(section.components, function (component) {
-				return component.name === targetComponentName
-			}))
-		})
+		forEach(sections, function(section) {
+			merge(filteredComponents, filter(section.components, function(component) {
+				return component.name === targetComponentName;
+			}));
+		});
 
 		ReactDOM.render(<StyleGuide config={config} components={filteredComponents} sections={[]} sidebar={false} />, document.getElementById('app'));
-	} else {
+	}
+	else {
 		ReactDOM.render(<StyleGuide config={config} components={components} sections={sections} />, document.getElementById('app'));
 	}
 }
 
-window.addEventListener("hashchange", renderStyleguide);
+window.addEventListener('hashchange', renderStyleguide);
 renderStyleguide();

--- a/src/rsg-components/Layout/Layout.css
+++ b/src/rsg-components/Layout/Layout.css
@@ -53,3 +53,6 @@
 .link {
 	composes: link from "../../styles/colors.css";
 }
+
+.withoutSidebar .wrapper { padding-left: 0; }
+.withoutSidebar .sidebar { display: none; }

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -14,6 +14,10 @@ const Layout = (Renderer) => class extends Component {
 		sidebar: PropTypes.bool
 	};
 
+	static defaultProps = {
+		sidebar: true
+	};
+
 	renderComponents(config, components, sections) {
 		if (!isEmpty(components) || !isEmpty(sections)) {
 			return (

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -10,7 +10,8 @@ const Layout = (Renderer) => class extends Component {
 	static propTypes = {
 		config: PropTypes.object.isRequired,
 		components: PropTypes.array.isRequired,
-		sections: PropTypes.array.isRequired
+		sections: PropTypes.array.isRequired,
+		sidebar: PropTypes.bool
 	};
 
 	renderComponents(config, components, sections) {
@@ -42,6 +43,7 @@ const Layout = (Renderer) => class extends Component {
 				components={this.renderComponents(config, components, sections)}
 				sections={this.props.sections}
 				toc={this.renderTableOfContents(components, sections)}
+				sidebar={this.props.sidebar}
 			/>
 		);
 	}

--- a/src/rsg-components/Layout/Renderer.jsx
+++ b/src/rsg-components/Layout/Renderer.jsx
@@ -1,9 +1,10 @@
 import {PropTypes} from 'react';
+import classnames from 'classnames';
 
 const s = require('./Layout.css');
 
-const Renderer = ({ title, components, toc }) => (
-	<div className={s.root}>
+const Renderer = ({ title, components, toc, sidebar }) => (
+	<div className={classnames(s.root, { [s.withoutSidebar]: !sidebar })}>
 		<main className={s.wrapper}>
 			<div className={s.content}>
 				<div className={s.components}>
@@ -24,7 +25,8 @@ const Renderer = ({ title, components, toc }) => (
 Renderer.propTypes = {
 	title: PropTypes.string.isRequired,
 	components: PropTypes.object.isRequired,
-	toc: PropTypes.node.isRequired
+	toc: PropTypes.node.isRequired,
+	sidebar: PropTypes.bool
 };
 
 export default Renderer;


### PR DESCRIPTION
**This is part of an ongoing project to look at speeding up webpack, as well as speeding up the development within styleguide driven development**

This has been mentioned in #98 and is something my team has struggled with as we look to use this library for styleguide driven development.

Currently, when using the styleguide and hot reload functionality to develop new components, or modify existing components, there is an issue with scroll position due to loading of code previews and rendered components between page reloads.

Although this could be solved with some extra functionality around page load and ensuring the page is scrolled to the correct position, our team decided that having a simple solution for viewing a single component on the page would be more beneficial. This PR includes the work responsible for implementing this functionality.

As noted, this is a WIP Pull Request and some of the implementation could be handled a little nicer. But I made a conscious effort to avoid something like react-router as it would definitely feel like overkill for such a simple task as this.

I've pushed this out for my team to use and will be looking at feedback from them to see if this helps, but i'm keen to get feedback from others here to see if this fixes up any issues you have with the existing styleguide.