### PR TITLE
[SPIKE] Filter component single view

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "glob": "6.0.4",
     "highlight.js": "9.1.0",
     "html-webpack-plugin": "2.8.1",
+    "immutable": "^3.7.6",
     "json-loader": "0.5.4",
     "lodash": "4.2.1",
     "markdown-it": "5.1.0",

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -1,6 +1,6 @@
 import { Component, PropTypes } from 'react';
 import ReactComponent from 'rsg-components/ReactComponent';
-import Renderer from 'rsg-components/ReactComponent/Renderer';
+import ReactComponentRenderer from 'rsg-components/ReactComponent/Renderer';
 import Sections from 'rsg-components/Sections';
 
 export default class Components extends Component {
@@ -12,10 +12,16 @@ export default class Components extends Component {
 
 	renderComponents() {
 		const { highlightTheme, components } = this.props;
-		const ComponentRenderer = ReactComponent(Renderer);
 
 		return components.map((component) => {
-			return (<ComponentRenderer key={component.name} highlightTheme={highlightTheme} component={component} />);
+			return (
+				<ReactComponent
+					renderer={ReactComponentRenderer}
+					key={component.name}
+					highlightTheme={highlightTheme}
+					component={component}
+				/>
+			);
 		});
 	}
 

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -1,18 +1,20 @@
 import { Component, PropTypes } from 'react';
 import Components from 'rsg-components/Components';
 import TableOfContents from 'rsg-components/TableOfContents';
+import Renderer from './Renderer';
 
 import s from './Layout.css';
 
 import isEmpty from 'lodash/isEmpty';
 
-const Layout = (Renderer) => class extends Component {
+class Layout extends Component {
 	static propTypes = {
 		config: PropTypes.object.isRequired,
 		components: PropTypes.array.isRequired,
 		sections: PropTypes.array.isRequired,
 		onSearchChange: PropTypes.func.isRequired,
-		onItemFocus: PropTypes.func.isRequired
+		onItemFocus: PropTypes.func.isRequired,
+		filter: PropTypes.string.isRequired
 	};
 
 	renderComponents(config, components, sections) {
@@ -38,6 +40,7 @@ const Layout = (Renderer) => class extends Component {
 				sections={sections}
 				onInputChange={this.props.onSearchChange}
 				onItemDoubleClick={this.props.onItemFocus}
+				filter={this.props.filter}
 			/>
 		);
 	}

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -10,7 +10,9 @@ const Layout = (Renderer) => class extends Component {
 	static propTypes = {
 		config: PropTypes.object.isRequired,
 		components: PropTypes.array.isRequired,
-		sections: PropTypes.array.isRequired
+		sections: PropTypes.array.isRequired,
+		onSearchChange: PropTypes.func.isRequired,
+		onItemFocus: PropTypes.func.isRequired
 	};
 
 	renderComponents(config, components, sections) {
@@ -30,7 +32,14 @@ const Layout = (Renderer) => class extends Component {
 	}
 
 	renderTableOfContents(components, sections) {
-		return <TableOfContents components={components} sections={sections} />;
+		return (
+			<TableOfContents
+				components={components}
+				sections={sections}
+				onInputChange={this.props.onSearchChange}
+				onItemDoubleClick={this.props.onItemFocus}
+			/>
+		);
 	}
 
 	render() {

--- a/src/rsg-components/ReactComponent/ReactComponent.css
+++ b/src/rsg-components/ReactComponent/ReactComponent.css
@@ -1,4 +1,5 @@
 .root {
+	display: none;
 	margin-bottom: 50px;
 	font-size: 16px;
 }
@@ -44,4 +45,8 @@
 .description {
 	composes: font from "../../styles/common.css";
 	margin-bottom: 15px;
+}
+
+.visible {
+	display: block;
 }

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -3,10 +3,11 @@ import Markdown from 'rsg-components/Markdown';
 import Props from 'rsg-components/Props';
 import Playground from 'rsg-components/Playground';
 
-const ReactComponent = (Renderer) => class extends Component {
+class ReactComponent extends Component {
 	static propTypes = {
 		highlightTheme: PropTypes.string.isRequired,
-		component: PropTypes.object.isRequired
+		component: PropTypes.object.isRequired,
+		renderer: PropTypes.func.isRequired
 	};
 
 	renderDescription(description) {
@@ -57,15 +58,14 @@ const ReactComponent = (Renderer) => class extends Component {
 	render() {
 		const {highlightTheme, component} = this.props;
 
-		return (
-			<Renderer
-				name={component.name}
-				pathLine={component.pathLine}
-				description={this.renderDescription(component.props.description)}
-				propList={this.renderProps(component.props)}
-				examples={this.renderExamples(highlightTheme, component.examples)}
-			/>
-		);
+		return this.props.renderer({
+			name: component.name,
+			pathLine: component.pathLine,
+			description: this.renderDescription(component.props.description),
+			propList: this.renderProps(component.props),
+			examples: this.renderExamples(highlightTheme, component.examples),
+			visible: component.visible
+		});
 	}
 };
 

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -64,7 +64,8 @@ class ReactComponent extends Component {
 			description: this.renderDescription(component.props.description),
 			propList: this.renderProps(component.props),
 			examples: this.renderExamples(highlightTheme, component.examples),
-			visible: component.visible
+			visible: component.visible,
+			active: component.active
 		});
 	}
 };

--- a/src/rsg-components/ReactComponent/Renderer.jsx
+++ b/src/rsg-components/ReactComponent/Renderer.jsx
@@ -1,10 +1,11 @@
 import {PropTypes} from 'react';
+import classnames from 'classnames';
 
 const s = require('./ReactComponent.css');
 
-const Renderer = ({ name, pathLine, description, propList, examples }) => {
+const Renderer = ({ name, pathLine, description, propList, examples, visible }) => {
 	return (
-		<div className={s.root}>
+		<div className={classnames(s.root, { [s.visible]: visible })}>
 			<header className={s.header}>
 				<h2 className={s.heading} id={name}>
 					<a className={s.anchor} href={'#' + name}></a>
@@ -26,7 +27,8 @@ Renderer.propTypes = {
 	pathLine: PropTypes.string.isRequired,
 	description: PropTypes.object,
 	propList: PropTypes.object,
-	examples: PropTypes.array
+	examples: PropTypes.array,
+	visible: PropTypes.bool
 };
 
 

--- a/src/rsg-components/ReactComponent/Renderer.jsx
+++ b/src/rsg-components/ReactComponent/Renderer.jsx
@@ -3,9 +3,9 @@ import classnames from 'classnames';
 
 const s = require('./ReactComponent.css');
 
-const Renderer = ({ name, pathLine, description, propList, examples, visible }) => {
+const Renderer = ({ name, pathLine, description, propList, examples, visible, active }) => {
 	return (
-		<div className={classnames(s.root, { [s.visible]: visible })}>
+		<div className={classnames(s.root, { [s.visible]: visible && active })}>
 			<header className={s.header}>
 				<h2 className={s.heading} id={name}>
 					<a className={s.anchor} href={'#' + name}></a>

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -13,18 +13,33 @@ export default class StyleGuide extends Component {
 	}
 
 	handleSearchChange(e) {
-		this.setState({ filter: e.target.value })
+		this.setState({ filter: e.target.value });
 	}
 
-	handleItemFocus(e) {
-		console.log('item focus')
+	handleItemFocus(item, e) {
+		if (this.state.active && this.state.active.name === item.name) {
+			this.setState({ active: null });
+		}
+		else {
+			this.setState({ active: item });
+		}
 	}
 
 	render() {
 		const components = this.state.components.map(component => {
 			const regexp = new RegExp(this.state.filter, 'gi');
-			return component.set('visible', regexp.test(component.get('name')));
+			component = component.set('visible', regexp.test(component.get('name')));
+
+			if (this.state.active && this.state.active !== null) {
+				component = component.set('active', this.state.active.name === component.get('name'));
+			} else {
+				component = component.set('active', true);
+			}
+
+			return component
 		})
+
+		console.log(components.toJS())
 
 		return (
 			<Layout

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -1,19 +1,19 @@
 import { Component } from 'react';
 import Immutable from 'immutable';
 import Layout from 'rsg-components/Layout';
-import Renderer from 'rsg-components/Layout/Renderer';
 
 export default class StyleGuide extends Component {
 	constructor (props){
 		super(props)
 		this.state = {
 			components: Immutable.fromJS(this.props.components),
-			sections: Immutable.fromJS(this.props.sections)
+			sections: Immutable.fromJS(this.props.sections),
+			filter: ''
 		}
 	}
 
 	handleSearchChange(e) {
-		console.log('search change')
+		this.setState({ filter: e.target.value })
 	}
 
 	handleItemFocus(e) {
@@ -21,15 +21,19 @@ export default class StyleGuide extends Component {
 	}
 
 	render() {
-		const LayoutRenderer = Layout(Renderer);
+		const components = this.state.components.map(component => {
+			const regexp = new RegExp(this.state.filter, 'gi');
+			return component.set('visible', regexp.test(component.get('name')));
+		})
 
 		return (
-			<LayoutRenderer
+			<Layout
 				{...this.props}
-				components={this.state.components.toJS()}
+				components={components.toJS()}
 				sections={this.state.sections.toJS()}
 				onSearchChange={this.handleSearchChange.bind(this)}
 				onItemFocus={this.handleItemFocus.bind(this)}
+				filter={this.state.filter}
 			/>
 		);
 	}

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -1,13 +1,36 @@
 import { Component } from 'react';
+import Immutable from 'immutable';
 import Layout from 'rsg-components/Layout';
 import Renderer from 'rsg-components/Layout/Renderer';
 
 export default class StyleGuide extends Component {
+	constructor (props){
+		super(props)
+		this.state = {
+			components: Immutable.fromJS(this.props.components),
+			sections: Immutable.fromJS(this.props.sections)
+		}
+	}
+
+	handleSearchChange(e) {
+		console.log('search change')
+	}
+
+	handleItemFocus(e) {
+		console.log('item focus')
+	}
+
 	render() {
 		const LayoutRenderer = Layout(Renderer);
 
 		return (
-			<LayoutRenderer {...this.props}/>
+			<LayoutRenderer
+				{...this.props}
+				components={this.state.components.toJS()}
+				sections={this.state.sections.toJS()}
+				onSearchChange={this.handleSearchChange.bind(this)}
+				onItemFocus={this.handleItemFocus.bind(this)}
+			/>
 		);
 	}
 }

--- a/src/rsg-components/TableOfContents/TableOfContents.css
+++ b/src/rsg-components/TableOfContents/TableOfContents.css
@@ -33,3 +33,5 @@
 	border-color: #1978c8;
 	outline: 0;
 }
+
+.inactive { opacity: 0.5; }

--- a/src/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/rsg-components/TableOfContents/TableOfContents.js
@@ -7,11 +7,7 @@ class TableOfContents extends Component {
 	renderLevel(components, sections) {
 		return (
 			<ul className={s.list}>
-				{(components || []).map(({ name }) => (
-					<li className={s.item} key={name}>
-						<a className={s.link} href={'#' + name} onDoubleClick={this.props.onItemDoubleClick}>{name}</a>
-					</li>
-				))}
+				{this.renderComponents(components)}
 				{(sections || []).map(({ name, components: subComponents, sections: subSections }) => (
 					<li key={name}>
 						<a className={s.section} href={'#' + name}>{name}</a>
@@ -20,6 +16,18 @@ class TableOfContents extends Component {
 				))}
 			</ul>
 		);
+	}
+
+	renderComponents (components) {
+		if (!components || !components.map) return null;
+		return components.map((component) => {
+			if (!component.visible) return null;
+			return (
+				<li className={s.item} key={component.name}>
+					<a className={s.link} href={'#' + component.name} onDoubleClick={this.props.onItemDoubleClick.bind(null, component)}>{component.name}</a>
+				</li>
+			)
+		})
 	}
 
 	render() {

--- a/src/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/rsg-components/TableOfContents/TableOfContents.js
@@ -1,17 +1,10 @@
 import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
 
 import s from './TableOfContents.css';
 
 class TableOfContents extends Component {
-	constructor(props) {
-		super(props);
-
-		this.state = {
-			searchTerm: ''
-		};
-	}
-
-	renderLevel(components, sections, searchTerm) {
+	renderLevel(components, sections) {
 		return (
 			<ul className={s.list}>
 				{(components || []).map(({ name }) => (
@@ -22,39 +15,33 @@ class TableOfContents extends Component {
 				{(sections || []).map(({ name, components: subComponents, sections: subSections }) => (
 					<li key={name}>
 						<a className={s.section} href={'#' + name}>{name}</a>
-						{this.renderLevel(subComponents, subSections, searchTerm)}
+						{this.renderLevel(subComponents, subSections)}
 					</li>
 				))}
 			</ul>
 		);
 	}
 
-	handleInputChange (e) {
-		this.setState({ searchTerm: e.target.value })
-		this.props.onInputChange(e)
-	}
-
 	render() {
-		let { searchTerm } = this.state;
 		let { components, sections } = this.props;
-
-		searchTerm = searchTerm.trim();
 
 		return (
 			<div className={s.root}>
 				<input
 					className={s.search}
 					placeholder="Filter by name"
-					onChange={this.handleInputChange.bind(this)}
-					value={searchTerm}
+					onChange={this.props.onInputChange}
+					value={this.props.filter}
+					ref='search'
 				/>
-				{this.renderLevel(components, sections, searchTerm)}
+				{this.renderLevel(components, sections)}
 			</div>
 		);
 	}
 }
 
 TableOfContents.propTypes = {
+	filter: PropTypes.string.isRequired,
 	components: PropTypes.array.isRequired,
 	sections: PropTypes.array.isRequired,
 	onInputChange: PropTypes.func.isRequired,

--- a/src/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/rsg-components/TableOfContents/TableOfContents.js
@@ -12,16 +12,11 @@ class TableOfContents extends Component {
 	}
 
 	renderLevel(components, sections, searchTerm) {
-		if (searchTerm !== '') {
-			let regExp = new RegExp(searchTerm.split('').join('.*'), 'gi');
-			components = components.filter(component => component.name.match(regExp));
-		}
-
 		return (
 			<ul className={s.list}>
 				{(components || []).map(({ name }) => (
 					<li className={s.item} key={name}>
-						<a className={s.link} href={'#' + name}>{name}</a>
+						<a className={s.link} href={'#' + name} onDoubleClick={this.props.onItemDoubleClick}>{name}</a>
 					</li>
 				))}
 				{(sections || []).map(({ name, components: subComponents, sections: subSections }) => (
@@ -32,6 +27,11 @@ class TableOfContents extends Component {
 				))}
 			</ul>
 		);
+	}
+
+	handleInputChange (e) {
+		this.setState({ searchTerm: e.target.value })
+		this.props.onInputChange(e)
 	}
 
 	render() {
@@ -45,7 +45,7 @@ class TableOfContents extends Component {
 				<input
 					className={s.search}
 					placeholder="Filter by name"
-					onChange={(e) => this.setState({ searchTerm: e.target.value })}
+					onChange={this.handleInputChange.bind(this)}
 					value={searchTerm}
 				/>
 				{this.renderLevel(components, sections, searchTerm)}
@@ -56,7 +56,9 @@ class TableOfContents extends Component {
 
 TableOfContents.propTypes = {
 	components: PropTypes.array.isRequired,
-	sections: PropTypes.array.isRequired
+	sections: PropTypes.array.isRequired,
+	onInputChange: PropTypes.func.isRequired,
+	onItemDoubleClick: PropTypes.func.isRequired
 };
 
 export default TableOfContents;

--- a/src/rsg-components/TableOfContents/TableOfContents.js
+++ b/src/rsg-components/TableOfContents/TableOfContents.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import ReactDOM from 'react-dom';
+import classnames from 'classnames';
 
 import s from './TableOfContents.css';
 
@@ -22,8 +23,9 @@ class TableOfContents extends Component {
 		if (!components || !components.map) return null;
 		return components.map((component) => {
 			if (!component.visible) return null;
+			console.log(component.active);
 			return (
-				<li className={s.item} key={component.name}>
+				<li className={classnames(s.item, {[s.inactive]: !component.active })} key={component.name}>
 					<a className={s.link} href={'#' + component.name} onDoubleClick={this.props.onItemDoubleClick.bind(null, component)}>{component.name}</a>
 				</li>
 			)


### PR DESCRIPTION
**DO NOT MERGE THIS! THIS IS A SPIKE, TESTING SOME POSSIBLE FUNCTIONALITY. TESTS MAY BREAK. THE IMPLEMENTATION WILL BE HACKED TOGETHER**

![filter-focus-styleguide](https://cloud.githubusercontent.com/assets/20490/14456316/df83bda2-00d6-11e6-8014-64f16ce55722.gif)

This is a look at how best to handle "focused components" within the styleguide. A focused component allows the user to view one component alone, this is useful when developing components using styleguide driven development.

The way this implementation works is by filtering the components using the search, then double clicking a component to "focus" on that item. This then removes the other filtered componets from the preview, and fades them out as "inactive" in the sidebar. Any change to the filter input, single clicking another item in the sidebar, or double clicking on the focus component, will clear this mode.

This is part of some ongoing work in #123 

cc @sapegin @mik01aj 