### PR TITLE
Fix cursor jumping while editing in codemirror

### DIFF
--- a/src/rsg-components/Editor/Editor.js
+++ b/src/rsg-components/Editor/Editor.js
@@ -11,7 +11,7 @@ import s from './Editor.css';
 
 var cssRequire = require.context('codemirror/theme/', false, /^\.\/.*\.css$/);
 
-let UPDATE_DELAY = 100;
+let UPDATE_DELAY = 10;
 
 export default class Editor extends Component {
 	static propTypes = {
@@ -38,6 +38,10 @@ export default class Editor extends Component {
 		let { highlightTheme } = this.props;
 
 		cssRequire(`./${highlightTheme}.css`);
+	}
+
+	shouldComponentUpdate() {
+		return false;
 	}
 
 	handleChange(newCode) {


### PR DESCRIPTION
Fixes https://github.com/sapegin/react-styleguidist/issues/139

The reason why this happens is because the `<Editor />` component re-renders when code changes by the editor itself. So when the `handleChange()` event is fired, it's re-rendering the `<Editor />` which resets where the cursor position is.

There's 2 ways to fix this. One way is to capture the current cursor position in `componentWillReceiveProps()` and then set it again in `componentDidUpdate()`, but that's a bit hacky and a lot of machinery for no real reason.

The other, and I think simpler approach (and what is implemented in this PR), is to just not have the `<Editor />`  update once it's been rendered, so it no longer reacts to property updates entirely. This is okay because we just need the codemirror editor rendered once and then just pass along any code changes to the `<Preview />` component from then on, which still responds and updates to code changes as expected.

With this implementation, we can even tighten up the `UPDATE_DELAY` if we wanted to. I changed it from 100 to 10 in this PR and it works great.