### PR TITLE
Add code toggleability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ examples/**/styleguide/build
 examples/**/styleguide/index.html
 .publish/
 node_modules/
+*.log

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -61,6 +61,10 @@ You can change settings in the `styleguide.config.js` file in your project’s r
 
   When writing your own default example file, `__COMPONENT__` will be replaced by the actual component name at compile-time.
 
+* **`showCode`**<br>
+  Type: `Boolean`, default: `false`<br>
+  Show or hide example code initially. It can be toggled in the UI by clicking the show/hide code toggle button underneath each example.
+
 * **`styleguideDir`**<br>
   Type: `String`, default: `styleguide`<br>
   Folder for static HTML style guide generated with `styleguidist build` command.

--- a/loaders/styleguide.loader.js
+++ b/loaders/styleguide.loader.js
@@ -100,7 +100,8 @@ module.exports.pitch = function() {
 
 	var simplifiedConfig = _.pick(config, [
 		'title',
-		'highlightTheme'
+		'highlightTheme',
+		'showCode'
 	]);
 
 	return [

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -8,14 +8,20 @@ export default class Components extends Component {
 		highlightTheme: PropTypes.string.isRequired,
 		components: PropTypes.array.isRequired,
 		sections: PropTypes.array.isRequired,
+		showCode: PropTypes.bool.isRequired,
 	};
 
 	renderComponents() {
-		const { highlightTheme, components } = this.props;
+		const { highlightTheme, components, showCode } = this.props;
 		const ComponentRenderer = ReactComponent(Renderer);
 
 		return components.map((component) => {
-			return (<ComponentRenderer key={component.name} highlightTheme={highlightTheme} component={component} />);
+			return (<ComponentRenderer
+						key={component.name}
+						highlightTheme={highlightTheme}
+						component={component}
+						showCode={showCode}
+					/>);
 		});
 	}
 

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -16,12 +16,14 @@ export default class Components extends Component {
 		const ComponentRenderer = ReactComponent(Renderer);
 
 		return components.map((component) => {
-			return (<ComponentRenderer
-						key={component.name}
-						highlightTheme={highlightTheme}
-						component={component}
-						showCode={showCode}
-					/>);
+			return (
+				<ComponentRenderer
+					key={component.name}
+					highlightTheme={highlightTheme}
+					component={component}
+					showCode={showCode}
+				/>
+			);
 		});
 	}
 

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -8,7 +8,6 @@ export default class Components extends Component {
 		highlightTheme: PropTypes.string.isRequired,
 		components: PropTypes.array.isRequired,
 		sections: PropTypes.array.isRequired,
-		showCode: PropTypes.bool.isRequired,
 	};
 
 	renderComponents() {
@@ -21,7 +20,6 @@ export default class Components extends Component {
 					key={component.name}
 					highlightTheme={highlightTheme}
 					component={component}
-					showCode={showCode}
 				/>
 			);
 		});

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -11,7 +11,7 @@ export default class Components extends Component {
 	};
 
 	renderComponents() {
-		const { highlightTheme, components, showCode } = this.props;
+		const { highlightTheme, components } = this.props;
 		const ComponentRenderer = ReactComponent(Renderer);
 
 		return components.map((component) => {

--- a/src/rsg-components/Layout/Layout.js
+++ b/src/rsg-components/Layout/Layout.js
@@ -18,6 +18,16 @@ const Layout = (Renderer) => class extends Component {
 		sidebar: true,
 	};
 
+	static childContextTypes = {
+		config: PropTypes.object.isRequired,
+	};
+
+	getChildContext() {
+		return {
+			config: this.props.config,
+		};
+	}
+
 	renderComponents(config, components, sections) {
 		if (!isEmpty(components) || !isEmpty(sections)) {
 			return (

--- a/src/rsg-components/Layout/Renderer.jsx
+++ b/src/rsg-components/Layout/Renderer.jsx
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import { PropTypes } from 'react';
 import classnames from 'classnames';
 
 const s = require('./Layout.css');
@@ -26,7 +26,7 @@ Renderer.propTypes = {
 	title: PropTypes.string.isRequired,
 	components: PropTypes.object.isRequired,
 	toc: PropTypes.node.isRequired,
-	sidebar: PropTypes.bool
+	sidebar: PropTypes.bool,
 };
 
 export default Renderer;

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -14,8 +14,7 @@
 
 .codeToggle {
 	composes: font from "../../styles/common.css";
-	composes: border from "../../styles/colors.css";
-	composes: link from "../../styles/colors.css";
+	composes: border link from "../../styles/colors.css";
 	cursor: pointer;
 	display: inline-block;
 	float: right;

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -21,8 +21,8 @@
 	float: right;
 	margin-bottom: -30px;
 	margin-right: -1px;
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
+	border-bottom-left-radius: 3px;
+	border-bottom-right-radius: 3px;
 	border-top: 0;
 	padding: 4px 8px;
 	font-size: small;

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -1,6 +1,5 @@
 .root {
 	composes: border from "../../styles/colors.css";
-	overflow: hidden;
 	margin-bottom: 30px;
 	border-radius: 3px;
 }
@@ -11,4 +10,30 @@
 .preview {
 	margin-bottom: 3px;
 	padding: 15px;
+}
+
+.codeToggle {
+	composes: font from "../../styles/common.css";
+	composes: border from "../../styles/colors.css";
+	composes: link from "../../styles/colors.css";
+	cursor: pointer;
+	display: inline-block;
+	float: right;
+	margin-bottom: -30px;
+	margin-right: -1px;
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	border-top: 0;
+	padding: 4px 8px;
+	font-size: small;
+}
+
+.showCode {
+	composes: codeToggle;
+	background: #fafafa;
+}
+
+.hideCode {
+	composes: codeToggle;
+	background: #f5f5f5;
 }

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -9,12 +9,14 @@ export default class Playground extends Component {
 		highlightTheme: PropTypes.string.isRequired,
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
+		showCode: PropTypes.bool,
 	};
 
 	constructor(props) {
 		super();
 		this.state = {
 			code: props.code,
+			showCode: false,
 		};
 	}
 
@@ -33,6 +35,12 @@ export default class Playground extends Component {
 		});
 	}
 
+	handleCodeToggle() {
+		this.setState({
+			showCode: !this.state.showCode,
+		});
+	}
+
 	render() {
 		let { code } = this.state;
 		let { highlightTheme } = this.props;
@@ -42,9 +50,18 @@ export default class Playground extends Component {
 				<div className={s.preview}>
 					<Preview code={code} evalInContext={this.props.evalInContext} />
 				</div>
-				<div className={s.editor}>
-					<Editor code={code} highlightTheme={highlightTheme} onChange={code => this.handleChange(code)} />
-				</div>
+				{this.state.showCode ? (
+					<div className={s.editor}>
+						<Editor code={code} highlightTheme={highlightTheme} onChange={code => this.handleChange(code)} />
+						<div className={s.hideCode} onClick={() => this.handleCodeToggle()}>
+							hide code
+						</div>
+					</div>
+				) : (
+					<div className={s.showCode} onClick={() => this.handleCodeToggle()}>
+						show code
+					</div>
+				)}
 			</div>
 		);
 	}

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -18,7 +18,7 @@ export default class Playground extends Component {
 	constructor(props, context) {
 		super(props, context);
 		const { code } = props;
-		const { config: { showCode } } = context;
+		const { showCode } = context.config;
 		this.state = {
 			code,
 			showCode,

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -9,14 +9,15 @@ export default class Playground extends Component {
 		highlightTheme: PropTypes.string.isRequired,
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
-		showCode: PropTypes.bool,
+		showCode: PropTypes.bool.isRequired,
 	};
 
 	constructor(props) {
-		super();
+		super(props);
+		const { code, showCode } = props;
 		this.state = {
-			code: props.code,
-			showCode: false,
+			code,
+			showCode,
 		};
 	}
 
@@ -29,9 +30,9 @@ export default class Playground extends Component {
 		}
 	}
 
-	handleChange(newCode) {
+	handleChange(code) {
 		this.setState({
-			code: newCode,
+			code,
 		});
 	}
 
@@ -42,7 +43,7 @@ export default class Playground extends Component {
 	}
 
 	render() {
-		let { code } = this.state;
+		let { code, showCode } = this.state;
 		let { highlightTheme } = this.props;
 
 		return (
@@ -50,7 +51,7 @@ export default class Playground extends Component {
 				<div className={s.preview}>
 					<Preview code={code} evalInContext={this.props.evalInContext} />
 				</div>
-				{this.state.showCode ? (
+				{showCode ? (
 					<div className={s.editor}>
 						<Editor code={code} highlightTheme={highlightTheme} onChange={code => this.handleChange(code)} />
 						<div className={s.hideCode} onClick={() => this.handleCodeToggle()}>

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -9,12 +9,16 @@ export default class Playground extends Component {
 		highlightTheme: PropTypes.string.isRequired,
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
-		showCode: PropTypes.bool.isRequired,
 	};
 
-	constructor(props) {
-		super(props);
-		const { code, showCode } = props;
+	static contextTypes = {
+		config: PropTypes.object.isRequired,
+	};
+
+	constructor(props, context) {
+		super(props, context);
+		const { code } = props;
+		const { config: { showCode } } = context;
 		this.state = {
 			code,
 			showCode,

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -7,6 +7,7 @@ const ReactComponent = (Renderer) => class extends Component {
 	static propTypes = {
 		highlightTheme: PropTypes.string.isRequired,
 		component: PropTypes.object.isRequired,
+		showCode: PropTypes.bool.isRequired,
 	};
 
 	renderDescription(description) {
@@ -27,7 +28,7 @@ const ReactComponent = (Renderer) => class extends Component {
 		);
 	}
 
-	renderExamples(highlightTheme, examples) {
+	renderExamples(highlightTheme, examples, showCode) {
 		if (!examples) {
 			return null;
 		}
@@ -41,6 +42,7 @@ const ReactComponent = (Renderer) => class extends Component {
 							evalInContext={example.evalInContext}
 							highlightTheme={highlightTheme}
 							key={index}
+							showCode={showCode}
 						/>
 					);
 				case 'markdown':
@@ -57,7 +59,7 @@ const ReactComponent = (Renderer) => class extends Component {
 	}
 
 	render() {
-		const { highlightTheme, component } = this.props;
+		const { highlightTheme, component, showCode } = this.props;
 
 		return (
 			<Renderer
@@ -65,7 +67,7 @@ const ReactComponent = (Renderer) => class extends Component {
 				pathLine={component.pathLine}
 				description={this.renderDescription(component.props.description)}
 				propList={this.renderProps(component.props)}
-				examples={this.renderExamples(highlightTheme, component.examples)}
+				examples={this.renderExamples(highlightTheme, component.examples, showCode)}
 			/>
 		);
 	}

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -7,7 +7,6 @@ const ReactComponent = (Renderer) => class extends Component {
 	static propTypes = {
 		highlightTheme: PropTypes.string.isRequired,
 		component: PropTypes.object.isRequired,
-		showCode: PropTypes.bool.isRequired,
 	};
 
 	renderDescription(description) {
@@ -28,7 +27,7 @@ const ReactComponent = (Renderer) => class extends Component {
 		);
 	}
 
-	renderExamples(highlightTheme, examples, showCode) {
+	renderExamples(highlightTheme, examples) {
 		if (!examples) {
 			return null;
 		}
@@ -42,7 +41,6 @@ const ReactComponent = (Renderer) => class extends Component {
 							evalInContext={example.evalInContext}
 							highlightTheme={highlightTheme}
 							key={index}
-							showCode={showCode}
 						/>
 					);
 				case 'markdown':
@@ -59,7 +57,7 @@ const ReactComponent = (Renderer) => class extends Component {
 	}
 
 	render() {
-		const { highlightTheme, component, showCode } = this.props;
+		const { highlightTheme, component } = this.props;
 
 		return (
 			<Renderer
@@ -67,7 +65,7 @@ const ReactComponent = (Renderer) => class extends Component {
 				pathLine={component.pathLine}
 				description={this.renderDescription(component.props.description)}
 				propList={this.renderProps(component.props)}
-				examples={this.renderExamples(highlightTheme, component.examples, showCode)}
+				examples={this.renderExamples(highlightTheme, component.examples)}
 			/>
 		);
 	}

--- a/src/rsg-components/ReactComponent/Renderer.jsx
+++ b/src/rsg-components/ReactComponent/Renderer.jsx
@@ -1,4 +1,4 @@
-import {PropTypes} from 'react';
+import { PropTypes } from 'react';
 
 const s = require('./ReactComponent.css');
 
@@ -25,7 +25,7 @@ Renderer.propTypes = {
 	pathLine: PropTypes.string.isRequired,
 	description: PropTypes.object,
 	propList: PropTypes.object,
-	examples: PropTypes.array
+	examples: PropTypes.array,
 };
 
 

--- a/src/rsg-components/Section/Renderer.jsx
+++ b/src/rsg-components/Section/Renderer.jsx
@@ -1,9 +1,9 @@
-import {PropTypes} from 'react';
+import { PropTypes } from 'react';
 
 const s = require('./Section.css');
 
-const Renderer = ({ name, content, components}) => {
-  return (
+const Renderer = ({ name, content, components }) => {
+  										return (
     <div className={s.root}>
       <header className={s.header}>
         <h1 className={s.heading} id={name}>
@@ -22,9 +22,9 @@ const Renderer = ({ name, content, components}) => {
 };
 
 Renderer.propTypes = {
-  name: PropTypes.string.isRequired,
-  content: PropTypes.array,
-  components: PropTypes.object
+  										name: PropTypes.string.isRequired,
+  										content: PropTypes.array,
+  										components: PropTypes.object,
 };
 
 

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -232,4 +232,6 @@ function findDependency(name, packageJson) {
 	return null;
 }
 
-module.exports = { initialize };
+module.exports = {
+	initialize: initialize,
+};

--- a/src/utils/config.js
+++ b/src/utils/config.js
@@ -16,6 +16,7 @@ var DEFAULT_CONFIG = {
 	sections: null,
 	skipComponentsWithoutExample: false,
 	defaultExample: false,
+	showCode: false,
 	title: 'Style guide',
 	styleguideDir: 'styleguide',
 	assetsDir: null,
@@ -231,6 +232,4 @@ function findDependency(name, packageJson) {
 	return null;
 }
 
-module.exports = {
-	initialize: initialize,
-};
+module.exports = { initialize };


### PR DESCRIPTION
Adds the ability to toggle the CodeMirror box:

![image](https://cloud.githubusercontent.com/assets/244704/15839200/1a3c8cee-2c10-11e6-9e22-c2541df70575.png)

![image](https://cloud.githubusercontent.com/assets/244704/15839211/2ab6474a-2c10-11e6-8a12-44ae59806fbd.png)

This _may_ help address https://github.com/sapegin/react-styleguidist/issues/86 but I'm actually not sure of the performance gains because I do not have a large testcase like the one in that issue. Below is the timeline for the basic example in the repo. You can see that rendering has improved and I imagine on a larger example case it could make a dramatic benefit. Either way, you can see that the 'Scripting' time is the big time suck, but that's a whole different story for another PR.

*Before*
![image](https://cloud.githubusercontent.com/assets/244704/15839253/633c1f36-2c10-11e6-909d-169a1c42628c.png)

*After*
![image](https://cloud.githubusercontent.com/assets/244704/15839261/6b8bb66a-2c10-11e6-9dce-28bc4bf5e52e.png)

I've also just done a very simple `if (showCode) { ... }` check, so not sure if there's an even more effective way to gain a performance boost by doing it another way or not, but at least it's a start.

It defaults to `showCode: false` in this branch, but I can have it default to `true` so it's not a "breaking" change, or even add it as a config option. Let me know!