### PR TITLE
Allow markdown ```example to render interactive example.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -101,18 +101,23 @@ Styleguidist generates documentation from three sources:
 
       <Button size="large">Push Me</Button>
 
-  One more:
+  One more with generic code fence:
 
   \`\`\`
   <Button size="large">Push Me</Button>
   \`\`\`
 
-  This example be rendered just as highlighted source code:
+  One more with `example` code fence (text editors may alias to `jsx` or `javascript`):
+  \`\`\`example
+  <Button size="large">Push Me</Button>
+  \`\`\`
+  
+  This example rendered only as highlighted source code:
 
   \`\`\`html
   <Button size="large">Push Me</Button>
   \`\`\`
-
+  
   Any [Markdown](http://daringfireball.net/projects/markdown/) is **allowed** _here_.
   ```
 

--- a/loaders/examples.loader.js
+++ b/loaders/examples.loader.js
@@ -23,7 +23,7 @@ function readExamples(markdown) {
 	md.renderer.rules.code_block = md.renderer.rules.fence = function(tokens, idx) {
 		var token = tokens[idx];
 		var code = tokens[idx].content.trim();
-		if (token.type === 'fence' && token.info && token.info !== 'jsx') {
+		if (token.type === 'fence' && token.info && token.info !== 'example') {
 			// Render fenced blocks with language flag as regular Markdown code snippets
 			var highlighted;
 			try {

--- a/loaders/examples.loader.js
+++ b/loaders/examples.loader.js
@@ -23,7 +23,7 @@ function readExamples(markdown) {
 	md.renderer.rules.code_block = md.renderer.rules.fence = function(tokens, idx) {
 		var token = tokens[idx];
 		var code = tokens[idx].content.trim();
-		if (token.type === 'fence' && token.info) {
+		if (token.type === 'fence' && token.info && token.info !== 'jsx') {
 			// Render fenced blocks with language flag as regular Markdown code snippets
 			var highlighted;
 			try {


### PR DESCRIPTION
Markdown fenced code blocks without a syntax prevent text editors from enabling syntax features within the code block.

This change allows fenced code blocks with `jsx` syntax to render the same as without a syntax specified.