### PR TITLE
Prevented breaking the app when the HTML is malformed.

### DIFF
--- a/src/rsg-components/Markdown/Markdown.js
+++ b/src/rsg-components/Markdown/Markdown.js
@@ -12,6 +12,13 @@ const voidTags = ['area', 'base', 'br', 'col', 'command', 'embed', 'hr', 'img', 
 	'param', 'source', 'track', 'wbr'];
 const bugsUrl = 'https://github.com/sapegin/react-styleguidist/issues';
 
+// Fixing malformed HTML (closing tags, fixing entities)
+function fixHTML(html) {
+	var div = document.createElement('div');
+	div.innerHTML = html;
+	return {__html: div.innerHTML};
+}
+
 function handleIterate(Tag, props, children) {
 	// Increase the level of headings
 	let m = Tag.match(headingRegExp);
@@ -41,7 +48,7 @@ function handleIterate(Tag, props, children) {
 
 	// Very basic HTML support
 	if (Tag === 'p' && children[0] && children[0][0] === '<') {
-		return <div key={props.key} dangerouslySetInnerHTML={{ __html: children }} />;
+		return <div key={props.key} dangerouslySetInnerHTML={fixHTML(children)} />;
 	}
 
 	// Avoid React warning about void elements with children


### PR DESCRIPTION
see https://github.com/sapegin/react-styleguidist/commit/552507f4a87c455ab26150cc141f3ce715952e59#commitcomment-18001050

NOTE: I haven't tested it. I just edited it directly on GitHub. Please test before merging.