### PR TITLE
Fix name plugin OccurrenceOrderPlugin

### DIFF
--- a/src/make-webpack-config.js
+++ b/src/make-webpack-config.js
@@ -121,7 +121,7 @@ module.exports = function(env) {
 			debug: false,
 			cache: false,
 			plugins: [
-				new webpack.optimize.OccurenceOrderPlugin(),
+				new webpack.optimize.OccurrenceOrderPlugin(),
 				new webpack.optimize.DedupePlugin(),
 				new webpack.optimize.UglifyJsPlugin({
 					compress: {


### PR DESCRIPTION
Hi!

Build styleguide from Webpack 2 not work.
This occurs because of an error in the name of the plugin OccurrenceOrderPlugin.

Relative link https://github.com/webpack/webpack/issues/1964