### PR TITLE
Fixed error reporting showing 'file is not defined'

### DIFF
--- a/loaders/props.loader.js
+++ b/loaders/props.loader.js
@@ -13,8 +13,8 @@ module.exports = function (source) {
 	};
 
 	var jsonProps;
+	const file = this.request.split('!').pop()
 	try {
-		const file = this.request.split('!').pop()
 		var propsParser = config.propsParser || defaultPropsParser;
 		var props = propsParser(file, source);
 


### PR DESCRIPTION
Hi!

The `file` variable should be set outside of the `try` statement because it is used in the `catch` error reporting. So when there's an error parsing a file I will only get:
```
ERROR in ./~/react-styleguidist/loaders/props.loader.js!./src/components/modal/prompt/Prompt.js
Module build failed: ReferenceError: file is not defined
    at Object.module.exports (/Users/adrien/Projects/dev-setup/tray/src/github.com/trayio/react-ui/node_modules/react-styleguidist/loaders/props.loader.js:41:66)
 @ ./~/react-styleguidist/loaders/styleguide.loader.js! 4:19905-20030
 @ ./~/react-styleguidist/src/index.js
 @ multi main
```
and after this fix I get the right error message:
```
Error when parsing src/components/modal/prompt/Prompt.js
Error: No suitable component definition found.
```