### PR TITLE
Expose webpack stats config on webpack dev middleware

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -142,6 +142,22 @@ You can change settings in the `styleguide.config.js` file in your project’s r
   };
   ```
 
+  You can also modify webpack dev server logs format passing `webpack.stats` options
+  inside `updateWebpackConfig`.
+  ```javascript
+  module.exports = {
+    // ...
+    updateWebpackConfig: function(webpackConfig, env) {
+      if (env === 'development') {
+        webpackConfig.stats.chunks = false;
+        webpackConfig.stats.chunkModules = false;
+        webpackConfig.stats.chunkOrigins = false;
+      }
+      return webpackConfig;
+    }
+  };
+  ```
+
   See [FAQ](./FAQ.md) for examples.
 
 * **`propsParser`**<br>

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -142,22 +142,6 @@ You can change settings in the `styleguide.config.js` file in your project’s r
   };
   ```
 
-  You can also modify webpack dev server logs format passing `webpack.stats` options
-  inside `updateWebpackConfig`.
-  ```javascript
-  module.exports = {
-    // ...
-    updateWebpackConfig: function(webpackConfig, env) {
-      if (env === 'development') {
-        webpackConfig.stats.chunks = false;
-        webpackConfig.stats.chunkModules = false;
-        webpackConfig.stats.chunkOrigins = false;
-      }
-      return webpackConfig;
-    }
-  };
-  ```
-
   See [FAQ](./FAQ.md) for examples.
 
 * **`propsParser`**<br>

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -163,6 +163,22 @@ export default class StyleGuide extends Component {
 2. Press the ![Debugger](http://wow.sapegin.me/image/2n2z0b0l320m/debugger.png) button in your browser’s developer tools.
 3. Press the ![Continue](http://wow.sapegin.me/image/2d2z1Y2o1z1m/continue.png) button and the debugger will stop execution at the next exception.
 
+## How to change style guide dev server logs output?
+You can modify webpack dev server logs format passing `webpack.stats` options inside `updateWebpackConfig`.
+```javascript
+module.exports = {
+  // ...
+  updateWebpackConfig: function(webpackConfig, env) {
+    if (env === 'development') {
+      webpackConfig.stats.chunks = false;
+      webpackConfig.stats.chunkModules = false;
+      webpackConfig.stats.chunkOrigins = false;
+    }
+    return webpackConfig;
+  }
+};
+```
+
 ## Why does the style guide list one of my prop types as `unknown`?
 
 This occurs when you are assigning props via `getDefaultProps` that are not listed within the components `propTypes`.

--- a/src/server.js
+++ b/src/server.js
@@ -9,23 +9,23 @@ config.initialize(); // we need to initialize config before requiring anything e
 var makeWebpackConfig = require('./make-webpack-config');
 
 module.exports = function server(callback) {
-	var app = express();
-       var webpackConfig = makeWebpackConfig('development');
-       var stats = webpackConfig.stats || {};
-	var compiler = webpack(webpackConfig);
+  var app = express();
+  var webpackConfig = makeWebpackConfig('development');
+  var stats = webpackConfig.stats || {};
+  var compiler = webpack(webpackConfig);
 
-	app.use(require('webpack-dev-middleware')(compiler, {
-		noInfo: true,
-               stats: stats,
-	}));
+  app.use(require('webpack-dev-middleware')(compiler, {
+    noInfo: true,
+    stats: stats,
+  }));
 
-	app.use(require('webpack-hot-middleware')(compiler));
+  app.use(require('webpack-hot-middleware')(compiler));
 
-	if (config.assetsDir) {
-		app.use(express.static(config.assetsDir));
-	}
+  if (config.assetsDir) {
+    app.use(express.static(config.assetsDir));
+  }
 
-	app.listen(config.serverPort, config.serverHost, function(err) {
-		callback(err, config);
-	});
+  app.listen(config.serverPort, config.serverHost, function(err) {
+    callback(err, config);
+  });
 };

--- a/src/server.js
+++ b/src/server.js
@@ -16,7 +16,7 @@ module.exports = function server(callback) {
 
 	app.use(require('webpack-dev-middleware')(compiler, {
 		noInfo: true,
-		stats: stats,
+		stats,
 	}));
 
 	app.use(require('webpack-hot-middleware')(compiler));

--- a/src/server.js
+++ b/src/server.js
@@ -9,23 +9,23 @@ config.initialize(); // we need to initialize config before requiring anything e
 var makeWebpackConfig = require('./make-webpack-config');
 
 module.exports = function server(callback) {
-  var app = express();
-  var webpackConfig = makeWebpackConfig('development');
-  var stats = webpackConfig.stats || {};
-  var compiler = webpack(webpackConfig);
+	var app = express();
+	var webpackConfig = makeWebpackConfig('development');
+	var stats = webpackConfig.stats || {};
+	var compiler = webpack(webpackConfig);
 
-  app.use(require('webpack-dev-middleware')(compiler, {
-    noInfo: true,
-    stats: stats,
-  }));
+	app.use(require('webpack-dev-middleware')(compiler, {
+		noInfo: true,
+		stats: stats,
+	}));
 
-  app.use(require('webpack-hot-middleware')(compiler));
+	app.use(require('webpack-hot-middleware')(compiler));
 
-  if (config.assetsDir) {
-    app.use(express.static(config.assetsDir));
-  }
+	if (config.assetsDir) {
+		app.use(express.static(config.assetsDir));
+	}
 
-  app.listen(config.serverPort, config.serverHost, function(err) {
-    callback(err, config);
-  });
+	app.listen(config.serverPort, config.serverHost, function(err) {
+		callback(err, config);
+	});
 };

--- a/src/server.js
+++ b/src/server.js
@@ -10,10 +10,13 @@ var makeWebpackConfig = require('./make-webpack-config');
 
 module.exports = function server(callback) {
 	var app = express();
-	var compiler = webpack(makeWebpackConfig('development'));
+       var webpackConfig = makeWebpackConfig('development');
+       var stats = webpackConfig.stats || {};
+	var compiler = webpack(webpackConfig);
 
 	app.use(require('webpack-dev-middleware')(compiler, {
 		noInfo: true,
+               stats: stats,
 	}));
 
 	app.use(require('webpack-hot-middleware')(compiler));


### PR DESCRIPTION
## Why?
I want to be able to manage what is the output of dev server. I think passing `webpack.stats` options to dev middleware is a good way. What do you think?