### PR TITLE
Update react-docgen version

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minimist": "1.2.0",
     "prettyjson": "1.1.3",
     "react-codemirror": "0.2.6",
-    "react-docgen": "2.9.1",
+    "react-docgen": "2.10.0",
     "remark": "~6.0.0",
     "remark-parse": "~2.0.1",
     "semver-utils": "1.1.1",


### PR DESCRIPTION
Hi! Thank you for awesome styleguide.

I'm using the Intersection types of flowtype.
At that time the following errors occurred.

```bash
ERROR in ./~/react-styleguidist/loaders/props.loader.js!./src/js/components/ui/IconButton/IconButton.js
Module build failed: ReferenceError: file is not defined
    at Object.module.exports (/Applications/XAMPP/xamppfiles/htdocs/flamber/node_modules/react-styleguidist/loaders/props.loader.js:40:66)
 @ ./~/react-styleguidist/loaders/styleguide.loader.js! 4:14908-15018

ERROR in ./~/react-styleguidist/loaders/props.loader.js!./src/js/components/ui/StarButton/StarButton.js
Module build failed: ReferenceError: file is not defined
    at Object.module.exports (/Applications/XAMPP/xamppfiles/htdocs/flamber/node_modules/react-styleguidist/loaders/props.loader.js:40:66)
 @ ./~/react-styleguidist/loaders/styleguide.loader.js! 4:31565-31675
Child html-webpack-plugin for "index.html":
         Asset    Size  Chunks       Chunk Names
    index.html  573 kB       0
    chunk    {0} index.html 534 kB [rendered]
        [0] ./~/html-webpack-plugin/lib/loader.js!./styleguide/index.html 579 bytes {0} [built]
        [1] ./~/lodash/lodash.js 533 kB {0} [built]
        [2] (webpack)/buildin/module.js 251 bytes {0} [built]
```

Errors in the react-docgen is looks like this is the cause.
However, in the latest version of the react-docgen since corrected that you want to update.

By the way, now we have to avoid to specify as follows the latest version of the react-docgen.

```javascript
// styleguide.config.js
module.exports = {
  // ...
  propsParser(filePath, source) {
    return require("react-docgen").parse(source);
  }
}
```

---

Ref: [reactjs/react-docgen Fix intersection and union flow types #118](https://github.com/reactjs/react-docgen/pull/118)