### PR TITLE
Refactoring: simplify PropsRenderer a bit

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "prettyjson": "1.1.3",
     "react-codemirror": "0.2.6",
     "react-docgen": "2.11.0",
+    "react-group": "^1.0.0",
     "remark": "~6.0.1",
     "remark-parse": "~2.0.2",
     "semver-utils": "1.1.1",

--- a/src/rsg-components/Props/Props.css
+++ b/src/rsg-components/Props/Props.css
@@ -41,19 +41,3 @@
 .type {
 	composes: type from "../../styles/colors.css";
 }
-
-.list {
-	display: inline;
-	margin: 0;
-	padding: 0;
-	list-style-type: none;
-}
-.listItem {
-	display: inline;
-}
-.listItem:after {
-	content: ", ";
-}
-.listItem:last-child:after {
-	content: "";
-}

--- a/src/rsg-components/Props/Props.spec.js
+++ b/src/rsg-components/Props/Props.spec.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import React from 'react';
 import { parse } from 'react-docgen';
+import Group from 'react-group';
 import Code from '../Code';
 import Markdown from '../Markdown';
 import PropsRenderer from './PropsRenderer';
@@ -20,7 +21,7 @@ function render(propTypes, defaultProps = []) {
 			}
 		}
 	`);
-	return shallow(<PropsRenderer props={props.props} />);
+	return shallow(<PropsRenderer props={props.props}/>);
 }
 
 test('should render PropTypes.string', () => {
@@ -31,7 +32,7 @@ test('should render PropTypes.string', () => {
 			<td><Code>color</Code></td>
 			<td><Code>string</Code></td>
 			<td></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });
@@ -44,7 +45,7 @@ test('should render PropTypes.string with a default value', () => {
 			<td><Code>color</Code></td>
 			<td><Code>string</Code></td>
 			<td><Code>pink</Code></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });
@@ -57,7 +58,7 @@ test('should render PropTypes.string.isRequired', () => {
 			<td><Code>color</Code></td>
 			<td><Code>string</Code></td>
 			<td><span>Required</span></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });
@@ -70,7 +71,7 @@ test('should render PropTypes.arrayOf', () => {
 			<td><Code>colors</Code></td>
 			<td><Code>string[]</Code></td>
 			<td></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });
@@ -83,28 +84,27 @@ test('should render PropTypes.instanceOf', () => {
 			<td><Code>num</Code></td>
 			<td><Code>Number</Code></td>
 			<td></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });
 
 test('should render PropTypes.shape', () => {
 	const actual = render(['foo: PropTypes.shape({bar: PropTypes.number.isRequired, baz: PropTypes.any})']);
-
 	expect(actual.node, 'to contain',
 		<tr>
 			<td><Code>foo</Code></td>
 			<td><Code>shape</Code></td>
 			<td></td>
 			<td>
-				<div>
+				<Group>
 					<div>
 						<Code>bar</Code>: <Code>number</Code> — <span>Required</span>
 					</div>
 					<div>
 						<Code>baz</Code>: <Code>any</Code>
 					</div>
-				</div>
+				</Group>
 			</td>
 		</tr>
 	);
@@ -118,7 +118,7 @@ test('should render description in Markdown', () => {
 			<td><Code>color</Code></td>
 			<td><Code>string</Code></td>
 			<td></td>
-			<td><div><Markdown text="Label" /></div></td>
+			<td><Group><Markdown text="Label"/></Group></td>
 		</tr>
 	);
 });
@@ -131,7 +131,7 @@ test('should render unknown proptype for a prop when a relevant proptype is not 
 			<td><Code>color</Code></td>
 			<td><Code>unknown</Code></td>
 			<td><Code>pink</Code></td>
-			<td><div /></td>
+			<td><Group /></td>
 		</tr>
 	);
 });

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -57,11 +57,10 @@ function renderDescription(prop) {
 	let { description } = prop;
 	let extra = renderExtra(prop);
 	return (
-		<div>
-			{description && <Markdown text={description} inline />}
-			{description && extra && ' '}
+		<Group separator=" ">
+			{description && <Markdown text={description} inline/>}
 			{extra}
-		</div>
+		</Group>
 	);
 }
 
@@ -127,7 +126,7 @@ function renderShape(props) {
 				<Code className={s.type}>{renderType(prop)}</Code>
 				{defaultValue && ' — '}{defaultValue}
 				{description && ' — '}
-				{description && <Markdown text={description} inline />}
+				{description && <Markdown text={description} inline/>}
 			</div>
 		);
 	}
@@ -138,15 +137,15 @@ export default function PropsRenderer({ props }) {
 	return (
 		<table className={s.table}>
 			<thead className={s.tableHead}>
-				<tr>
-					<th className={s.cellHeading}>Name</th>
-					<th className={s.cellHeading}>Type</th>
-					<th className={s.cellHeading}>Default</th>
-					<th className={s.cellHeading + ' ' + s.cellDesc}>Description</th>
-				</tr>
+			<tr>
+				<th className={s.cellHeading}>Name</th>
+				<th className={s.cellHeading}>Type</th>
+				<th className={s.cellHeading}>Default</th>
+				<th className={s.cellHeading + ' ' + s.cellDesc}>Description</th>
+			</tr>
 			</thead>
 			<tbody className={s.tableBody}>
-				{renderRows(props)}
+			{renderRows(props)}
 			</tbody>
 		</table>
 	);

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -106,7 +106,7 @@ function renderUnion(prop) {
 		return <span>{getType(prop).value}</span>;
 	}
 	let values = getType(prop).value.map((value) => (
-		<Code className={s.type}>{renderType(value)}</Code>
+		<Code>{renderType(value)}</Code>
 	));
 
 	return (

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -57,7 +57,7 @@ function renderDescription(prop) {
 	let { description } = prop;
 	let extra = renderExtra(prop);
 	return (
-		<Group separator=" ">
+		<Group>
 			{description && <Markdown text={description} inline />}
 			{extra}
 		</Group>
@@ -97,7 +97,7 @@ function renderEnum(prop) {
 	));
 
 	return (
-		<span>One of: <Group separator=", ">{values}</Group></span>
+		<span>One of: <Group separator=", " inline>{values}</Group></span>
 	);
 }
 
@@ -110,7 +110,7 @@ function renderUnion(prop) {
 	));
 
 	return (
-		<span>One of type: <Group seperator=", ">{values}</Group></span>
+		<span>One of type: <Group seperator=", " inline>{values}</Group></span>
 	);
 }
 
@@ -132,7 +132,6 @@ function renderShape(props) {
 	}
 	return rows;
 }
-
 
 export default function PropsRenderer({ props }) {
 	return (

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -97,7 +97,7 @@ function renderEnum(prop) {
 	));
 
 	return (
-		<span> One of: <Group className={s.list} separator=", ">children={values}</Group></span>
+		<span>One of: <Group separator=", ">{values}</Group></span>
 	);
 }
 
@@ -110,7 +110,7 @@ function renderUnion(prop) {
 	));
 
 	return (
-		<span>One of type: <Group className={s.list} seperator=", ">children{values}</Group></span>
+		<span>One of type: <Group seperator=", ">{values}</Group></span>
 	);
 }
 
@@ -132,6 +132,7 @@ function renderShape(props) {
 	}
 	return rows;
 }
+
 
 export default function PropsRenderer({ props }) {
 	return (

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -106,7 +106,7 @@ function renderUnion(prop) {
 		return <span>{getType(prop).value}</span>;
 	}
 	let values = getType(prop).value.map((value) => (
-		<Code>{renderType(value)}</Code>
+		<Code className={s.type}>{renderType(value)}</Code>
 	));
 
 	return (

--- a/src/rsg-components/Props/PropsRenderer.js
+++ b/src/rsg-components/Props/PropsRenderer.js
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import Code from 'rsg-components/Code';
 import Markdown from 'rsg-components/Markdown';
+import Group from 'react-group';
 import { unquote, getType } from './util';
 
 import s from './Props.css';
@@ -93,12 +94,11 @@ function renderEnum(prop) {
 		return <span>{getType(prop).value}</span>;
 	}
 	let values = getType(prop).value.map(({ value }) => (
-		<li className={s.listItem} key={value}>
-			<Code>{unquote(value)}</Code>
-		</li>
+		<Code>{unquote(value)}</Code>
 	));
+
 	return (
-		<span>One of: <ul className={s.list}>{values}</ul></span>
+		<span> One of: <Group className={s.list} separator=", ">children={values}</Group></span>
 	);
 }
 
@@ -106,14 +106,12 @@ function renderUnion(prop) {
 	if (!Array.isArray(getType(prop).value)) {
 		return <span>{getType(prop).value}</span>;
 	}
-	let values = getType(prop).value.map((value, index) => (
-		<li className={s.listItem} key={value.name + index}>
-			<Code className={s.type}>{renderType(value)}</Code>
-		</li>
+	let values = getType(prop).value.map((value) => (
+		<Code className={s.type}>{renderType(value)}</Code>
 	));
 
 	return (
-		<span>One of type: <ul className={s.list}>{values}</ul></span>
+		<span>One of type: <Group className={s.list} seperator=", ">children{values}</Group></span>
 	);
 }
 

--- a/src/rsg-components/Props/util.js
+++ b/src/rsg-components/Props/util.js
@@ -5,7 +5,7 @@
  * @returns {string}
  */
 export function unquote(string) {
-	return string.replace(/^'|^"|"$|'$/g, '');
+	return string.replace(/^\'|^\"|\"$|\'$/g, '');
 }
 
 /**


### PR DESCRIPTION
This PR closes #194. It replaces li/ul tags with `react-group` package and simplifies `renderDescription`. The specs were fixed to reflect this changes.