### PR TITLE
Enable isolation of a single fenced block example

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import _ from 'lodash';
+import isFinite from 'lodash/isFinite';
 import ReactDOM from 'react-dom';
 import {
 	getComponentNameFromHash,
@@ -28,7 +29,15 @@ function renderStyleguide() {
 	let sidebar = true;
 	let singleExample = false;
 
-	const { targetComponentName, targetComponentIndex } = getComponentNameFromHash();
+	// parse url hash to check if the components list must be filtered
+	const {
+		// name of the filtered component to show isolated
+		targetComponentName,
+		// index of the fenced block example of the filtered component isolate
+		targetComponentIndex,
+	} = getComponentNameFromHash();
+
+	// filter the requested component id required
 	if (targetComponentName) {
 		components = [
 			...filterComponentsByExactName(components, targetComponentName),
@@ -37,7 +46,8 @@ function renderStyleguide() {
 		sections = [];
 		sidebar = false;
 
-		if (components.length === 1 && _.isFinite(targetComponentIndex)) {
+		// if a single component is filtered and a fenced block index is specified hide the other examples
+		if (components.length === 1 && isFinite(targetComponentIndex)) {
 			components[0] = filterComponentExamples(components[0], targetComponentIndex);
 			singleExample = true;
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import {
 	getComponentNameFromHash,
 	filterComponentsByExactName,
+	filterComponentExamples,
 	filterComponentsInSectionsByExactName,
 	processComponents,
 	processSections,
@@ -25,8 +26,9 @@ function renderStyleguide() {
 	let components = processComponents(styleguide.components);
 	let sections = processSections(styleguide.sections || []);
 	let sidebar = true;
+	let singleExample = false;
 
-	const targetComponentName = getComponentNameFromHash();
+	const { targetComponentName, targetComponentIndex } = getComponentNameFromHash();
 	if (targetComponentName) {
 		components = [
 			...filterComponentsByExactName(components, targetComponentName),
@@ -34,6 +36,11 @@ function renderStyleguide() {
 		];
 		sections = [];
 		sidebar = false;
+
+		if (components.length === 1 && _.isFinite(targetComponentIndex)) {
+			components[0] = filterComponentExamples(components[0], targetComponentIndex);
+			singleExample = true;
+		}
 	}
 
 	ReactDOM.render(
@@ -43,6 +50,7 @@ function renderStyleguide() {
 			components={components}
 			sections={sections}
 			sidebar={sidebar}
+			singleExample={singleExample}
 		/>,
 		document.getElementById('app')
 	);

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -7,14 +7,12 @@ export default function Components({
 	components,
 	sections,
 	sidebar,
-	singleExample,
 }) {
 	const componentsJsx = components.map(component => (
 		<ReactComponent
 			key={component.filepath}
 			component={component}
 			sidebar={sidebar}
-			singleExample={singleExample}
 		/>
 	));
 
@@ -37,5 +35,4 @@ Components.propTypes = {
 	components: PropTypes.array.isRequired,
 	sections: PropTypes.array.isRequired,
 	sidebar: PropTypes.bool,
-	singleExample: PropTypes.bool,
 };

--- a/src/rsg-components/Components/Components.js
+++ b/src/rsg-components/Components/Components.js
@@ -7,12 +7,14 @@ export default function Components({
 	components,
 	sections,
 	sidebar,
+	singleExample,
 }) {
 	const componentsJsx = components.map(component => (
 		<ReactComponent
 			key={component.filepath}
 			component={component}
 			sidebar={sidebar}
+			singleExample={singleExample}
 		/>
 	));
 
@@ -35,4 +37,5 @@ Components.propTypes = {
 	components: PropTypes.array.isRequired,
 	sections: PropTypes.array.isRequired,
 	sidebar: PropTypes.bool,
+	singleExample: PropTypes.bool,
 };

--- a/src/rsg-components/Examples/Examples.js
+++ b/src/rsg-components/Examples/Examples.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import Playground from 'rsg-components/Playground';
 import Markdown from 'rsg-components/Markdown';
 
-const Examples = ({ examples }, { codeKey }) => {
+const Examples = ({ examples, name, singleExample }, { codeKey }) => {
 	return (
 		<div>
 			{examples.map((example, index) => {
@@ -13,6 +13,9 @@ const Examples = ({ examples }, { codeKey }) => {
 								code={example.content}
 								evalInContext={example.evalInContext}
 								key={`${codeKey}/${index}`}
+								name={name}
+								index={index}
+								singleExample={singleExample}
 							/>
 						);
 					case 'markdown':
@@ -32,6 +35,8 @@ const Examples = ({ examples }, { codeKey }) => {
 
 Examples.propTypes = {
 	examples: PropTypes.array.isRequired,
+	name: PropTypes.string.isRequired,
+	singleExample: PropTypes.bool,
 };
 Examples.contextTypes = {
 	codeKey: PropTypes.number.isRequired,

--- a/src/rsg-components/Examples/Examples.js
+++ b/src/rsg-components/Examples/Examples.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import Playground from 'rsg-components/Playground';
 import Markdown from 'rsg-components/Markdown';
 
-const Examples = ({ examples, name, singleExample }, { codeKey }) => {
+const Examples = ({ examples, name }, { codeKey }) => {
 	return (
 		<div>
 			{examples.map((example, index) => {
@@ -15,7 +15,6 @@ const Examples = ({ examples, name, singleExample }, { codeKey }) => {
 								key={`${codeKey}/${index}`}
 								name={name}
 								index={index}
-								singleExample={singleExample}
 							/>
 						);
 					case 'markdown':
@@ -36,7 +35,6 @@ const Examples = ({ examples, name, singleExample }, { codeKey }) => {
 Examples.propTypes = {
 	examples: PropTypes.array.isRequired,
 	name: PropTypes.string.isRequired,
-	singleExample: PropTypes.bool,
 };
 Examples.contextTypes = {
 	codeKey: PropTypes.number.isRequired,

--- a/src/rsg-components/Examples/Examples.spec.js
+++ b/src/rsg-components/Examples/Examples.spec.js
@@ -26,6 +26,7 @@ test('should render examples', () => {
 		{
 			context: {
 				codeKey: 1,
+				singleExample: false,
 			},
 		}
 	);

--- a/src/rsg-components/Examples/Examples.spec.js
+++ b/src/rsg-components/Examples/Examples.spec.js
@@ -21,6 +21,7 @@ test('should render examples', () => {
 	const actual = shallow(
 		<Examples
 			examples={examples}
+			name="button"
 		/>,
 		{
 			context: {
@@ -33,6 +34,8 @@ test('should render examples', () => {
 		<Playground
 			code={examples[0].content}
 			evalInContext={examples[0].evalInContext}
+			name="button"
+			index={0}
 		/>
 	);
 	expect(actual.node, 'to contain',

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -25,26 +25,6 @@
 	line-height: 1;
 }
 
-.showCodeTotoRight {
-	right: -1px;
-}
-
-.showCodeToLeft {
-	right: 138px;
-}
-
-.isolateExample {
-	composes: base-bg from "../../styles/colors.css";
-	composes: codeToggle;
-	composes: showCodeTotoRight;
-}
-
-.exitIsolation {
-	composes: base-bg from "../../styles/colors.css";
-	composes: codeToggle;
-	right: 90px;
-}
-
 .showCode {
 	composes: base-bg from "../../styles/colors.css";
 	composes: codeToggle;
@@ -53,4 +33,20 @@
 .hideCode {
 	composes: code-bg from "../../styles/colors.css";
 	composes: codeToggle;
+}
+
+.isolatedLink {
+	composes: font from "../../styles/common.css";
+	composes: link from "../../styles/colors.css";
+	position: absolute;
+	top: 0;
+	right: 0;
+	font-size: 14px;
+	padding: 6px 8px;
+	opacity: 0;
+	transition: opacity ease-in-out .15s .2s;
+}
+
+.root:hover .isolatedLink {
+	opacity: 1;
 }

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -14,7 +14,7 @@
 	composes: font from "../../styles/common.css";
 	composes: border link from "../../styles/colors.css";
 	position: absolute;
-	right: 138px;
+	right: -1px;
 	bottom: -27px;
 	cursor: pointer;
 	border-bottom-left-radius: 3px;
@@ -25,10 +25,18 @@
 	line-height: 1;
 }
 
+.showCodeTotoRight {
+	right: -1px;
+}
+
+.showCodeToLeft {
+	right: 138px;
+}
+
 .isolateExample {
 	composes: base-bg from "../../styles/colors.css";
 	composes: codeToggle;
-	right: -1px;
+	composes: showCodeTotoRight;
 }
 
 .exitIsolation {
@@ -45,8 +53,4 @@
 .hideCode {
 	composes: code-bg from "../../styles/colors.css";
 	composes: codeToggle;
-}
-
-.toRight {
-	right: -1px;
 }

--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -14,7 +14,7 @@
 	composes: font from "../../styles/common.css";
 	composes: border link from "../../styles/colors.css";
 	position: absolute;
-	right: -1px;
+	right: 138px;
 	bottom: -27px;
 	cursor: pointer;
 	border-bottom-left-radius: 3px;
@@ -25,6 +25,18 @@
 	line-height: 1;
 }
 
+.isolateExample {
+	composes: base-bg from "../../styles/colors.css";
+	composes: codeToggle;
+	right: -1px;
+}
+
+.exitIsolation {
+	composes: base-bg from "../../styles/colors.css";
+	composes: codeToggle;
+	right: 90px;
+}
+
 .showCode {
 	composes: base-bg from "../../styles/colors.css";
 	composes: codeToggle;
@@ -33,4 +45,8 @@
 .hideCode {
 	composes: code-bg from "../../styles/colors.css";
 	composes: codeToggle;
+}
+
+.toRight {
+	right: -1px;
 }

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -7,10 +7,10 @@ export default class Playground extends Component {
 		evalInContext: PropTypes.func.isRequired,
 		index: PropTypes.number.isRequired,
 		name: PropTypes.string.isRequired,
-		singleExample: PropTypes.bool,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
+		singleExample: PropTypes.bool,
 	};
 
 	constructor(props, context) {
@@ -51,7 +51,8 @@ export default class Playground extends Component {
 
 	render() {
 		const { code, showCode } = this.state;
-		const { evalInContext, index, name, singleExample } = this.props;
+		const { evalInContext, index, name } = this.props;
+		const { singleExample } = this.context;
 		return (
 			<PlaygroundRenderer
 				code={code}

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -5,6 +5,9 @@ export default class Playground extends Component {
 	static propTypes = {
 		code: PropTypes.string.isRequired,
 		evalInContext: PropTypes.func.isRequired,
+		index: PropTypes.number.isRequired,
+		name: PropTypes.string.isRequired,
+		singleExample: PropTypes.bool,
 	};
 	static contextTypes = {
 		config: PropTypes.object.isRequired,
@@ -48,11 +51,14 @@ export default class Playground extends Component {
 
 	render() {
 		const { code, showCode } = this.state;
-		const { evalInContext } = this.props;
+		const { evalInContext, index, name, singleExample } = this.props;
 		return (
 			<PlaygroundRenderer
 				code={code}
 				showCode={showCode}
+				index={index}
+				name={name}
+				singleExample={singleExample}
 				evalInContext={evalInContext}
 				onChange={code => this.handleChange(code)}
 				onCodeToggle={() => this.handleCodeToggle()}

--- a/src/rsg-components/Playground/Playground.spec.js
+++ b/src/rsg-components/Playground/Playground.spec.js
@@ -12,6 +12,8 @@ test('should render component renderer', () => {
 		<Playground
 			code={code}
 			evalInContext={noop}
+			name="name"
+			index={0}
 		/>,
 		{
 			context: {
@@ -27,6 +29,8 @@ test('should render component renderer', () => {
 			code={code}
 			showCode={false}
 			evalInContext={noop}
+			name="name"
+			index={0}
 		/>
 	);
 });
@@ -37,6 +41,8 @@ test('renderer should render preview', () => {
 			code={code}
 			showCode={false}
 			evalInContext={noop}
+			name="name"
+			index={0}
 		/>
 	);
 

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import cx from 'classnames';
 import Editor from 'rsg-components/Editor';
 import Preview from 'rsg-components/Preview';
 
@@ -14,34 +13,30 @@ const PlaygroundRenderer = ({
 	evalInContext,
 	onChange,
 	onCodeToggle,
-}) => {
-	const positionCode = {
-		[s.showCodeTotoRight]: singleExample,
-		[s.showCodeToLeft]: !singleExample,
-	};
-
-	return (
-		<div className={s.root}>
-			<div className={s.preview}>
-				<Preview code={code} evalInContext={evalInContext} />
-			</div>
-			{singleExample && <a className={s.exitIsolation} href={'#!/' + name}>⇽ Exit Isolation</a>}
-			{showCode ? (
-				<div>
-					<Editor code={code} onChange={onChange} />
-					<button type="button" className={cx(s.hideCode, positionCode)} onClick={onCodeToggle}>
-						Hide code
-					</button>
-				</div>
+}) => (
+	<div className={s.root}>
+		<div className={s.preview}>
+			{singleExample ? (
+				<a className={s.isolatedLink} href={'#!/' + name}>⇽ Exit Isolation</a>
 			) : (
-				<button type="button" className={cx(s.showCode, positionCode)} onClick={onCodeToggle}>
-					Show code
-				</button>
+				<a className={s.isolatedLink} href={'#!/' + name + '/' + index}>Open isolated ⇢</a>
 			)}
-			{!singleExample && <a className={s.isolateExample} href={'#!/' + name + '/' + index}>Isolate Example ⇢</a>}
+			<Preview code={code} evalInContext={evalInContext} />
 		</div>
-	);
-};
+		{showCode ? (
+			<div>
+				<Editor code={code} onChange={onChange} />
+				<button type="button" className={s.hideCode} onClick={onCodeToggle}>
+					Hide code
+				</button>
+			</div>
+		) : (
+			<button type="button" className={s.showCode} onClick={onCodeToggle}>
+				Show code
+			</button>
+		)}
+	</div>
+);
 
 PlaygroundRenderer.propTypes = {
 	code: PropTypes.string.isRequired,

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -14,27 +14,34 @@ const PlaygroundRenderer = ({
 	evalInContext,
 	onChange,
 	onCodeToggle,
-}) => (
-	<div className={s.root}>
-		<div className={s.preview}>
-			<Preview code={code} evalInContext={evalInContext} />
-		</div>
-		{singleExample && <a className={s.exitIsolation} href={'#!/' + name}>⇽ Exit Isolation</a>}
-		{showCode ? (
-			<div>
-				<Editor code={code} onChange={onChange} />
-				<button type="button" className={cx(s.hideCode, { [s.toRight]: singleExample })} onClick={onCodeToggle}>
-					Hide code
-				</button>
+}) => {
+	const positionCode = {
+		[s.showCodeTotoRight]: singleExample,
+		[s.showCodeToLeft]: !singleExample,
+	};
+
+	return (
+		<div className={s.root}>
+			<div className={s.preview}>
+				<Preview code={code} evalInContext={evalInContext} />
 			</div>
-		) : (
-			<button type="button" className={cx(s.showCode, { [s.toRight]: singleExample })} onClick={onCodeToggle}>
-				Show code
-			</button>
-		)}
-		{!singleExample && <a className={s.isolateExample} href={'#!/' + name + '/' + index}>Isolate Example ⇢</a>}
-	</div>
-);
+			{singleExample && <a className={s.exitIsolation} href={'#!/' + name}>⇽ Exit Isolation</a>}
+			{showCode ? (
+				<div>
+					<Editor code={code} onChange={onChange} />
+					<button type="button" className={cx(s.hideCode, positionCode)} onClick={onCodeToggle}>
+						Hide code
+					</button>
+				</div>
+			) : (
+				<button type="button" className={cx(s.showCode, positionCode)} onClick={onCodeToggle}>
+					Show code
+				</button>
+			)}
+			{!singleExample && <a className={s.isolateExample} href={'#!/' + name + '/' + index}>Isolate Example ⇢</a>}
+		</div>
+	);
+};
 
 PlaygroundRenderer.propTypes = {
 	code: PropTypes.string.isRequired,

--- a/src/rsg-components/Playground/PlaygroundRenderer.js
+++ b/src/rsg-components/Playground/PlaygroundRenderer.js
@@ -1,35 +1,50 @@
 import React, { PropTypes } from 'react';
+import cx from 'classnames';
 import Editor from 'rsg-components/Editor';
 import Preview from 'rsg-components/Preview';
 
 const s = require('./Playground.css');
 
-const PlaygroundRenderer = ({ code, showCode, evalInContext, onChange, onCodeToggle }) => (
+const PlaygroundRenderer = ({
+	code,
+	showCode,
+	name,
+	index,
+	singleExample,
+	evalInContext,
+	onChange,
+	onCodeToggle,
+}) => (
 	<div className={s.root}>
 		<div className={s.preview}>
 			<Preview code={code} evalInContext={evalInContext} />
 		</div>
+		{singleExample && <a className={s.exitIsolation} href={'#!/' + name}>⇽ Exit Isolation</a>}
 		{showCode ? (
 			<div>
 				<Editor code={code} onChange={onChange} />
-				<button type="button" className={s.hideCode} onClick={onCodeToggle}>
+				<button type="button" className={cx(s.hideCode, { [s.toRight]: singleExample })} onClick={onCodeToggle}>
 					Hide code
 				</button>
 			</div>
 		) : (
-			<button type="button" className={s.showCode} onClick={onCodeToggle}>
+			<button type="button" className={cx(s.showCode, { [s.toRight]: singleExample })} onClick={onCodeToggle}>
 				Show code
 			</button>
 		)}
+		{!singleExample && <a className={s.isolateExample} href={'#!/' + name + '/' + index}>Isolate Example ⇢</a>}
 	</div>
 );
 
 PlaygroundRenderer.propTypes = {
 	code: PropTypes.string.isRequired,
 	showCode: PropTypes.bool.isRequired,
+	name: PropTypes.string.isRequired,
+	index: PropTypes.number.isRequired,
 	evalInContext: PropTypes.func.isRequired,
 	onChange: PropTypes.func.isRequired,
 	onCodeToggle: PropTypes.func.isRequired,
+	singleExample: PropTypes.bool,
 };
 
 export default PlaygroundRenderer;

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -7,7 +7,6 @@ import ReactComponentRenderer from 'rsg-components/ReactComponent/ReactComponent
 export default function ReactComponent({
 	component,
 	sidebar,
-	singleExample,
 }) {
 	const { name, pathLine, examples } = component;
 	const { description, props } = component.props;
@@ -17,7 +16,7 @@ export default function ReactComponent({
 			pathLine={pathLine}
 			description={description && <Markdown text={description} />}
 			props={props && <Props props={props} />}
-			examples={examples && <Examples examples={examples} name={name} singleExample={singleExample} />}
+			examples={examples && <Examples examples={examples} name={name} />}
 			sidebar={sidebar}
 		/>
 	);
@@ -26,5 +25,4 @@ export default function ReactComponent({
 ReactComponent.propTypes = {
 	component: PropTypes.object.isRequired,
 	sidebar: PropTypes.bool,
-	singleExample: PropTypes.bool,
 };

--- a/src/rsg-components/ReactComponent/ReactComponent.js
+++ b/src/rsg-components/ReactComponent/ReactComponent.js
@@ -7,6 +7,7 @@ import ReactComponentRenderer from 'rsg-components/ReactComponent/ReactComponent
 export default function ReactComponent({
 	component,
 	sidebar,
+	singleExample,
 }) {
 	const { name, pathLine, examples } = component;
 	const { description, props } = component.props;
@@ -16,7 +17,7 @@ export default function ReactComponent({
 			pathLine={pathLine}
 			description={description && <Markdown text={description} />}
 			props={props && <Props props={props} />}
-			examples={examples && <Examples examples={examples} />}
+			examples={examples && <Examples examples={examples} name={name} singleExample={singleExample} />}
 			sidebar={sidebar}
 		/>
 	);
@@ -25,4 +26,5 @@ export default function ReactComponent({
 ReactComponent.propTypes = {
 	component: PropTypes.object.isRequired,
 	sidebar: PropTypes.bool,
+	singleExample: PropTypes.bool,
 };

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -12,6 +12,7 @@ export default class StyleGuide extends Component {
 		components: PropTypes.array.isRequired,
 		sections: PropTypes.array.isRequired,
 		sidebar: PropTypes.bool,
+		singleExample: PropTypes.bool,
 	};
 	static defaultProps = {
 		sidebar: true,
@@ -28,13 +29,14 @@ export default class StyleGuide extends Component {
 		};
 	}
 
-	renderComponents(components, sections, sidebar) {
+	renderComponents(components, sections, sidebar, singleExample) {
 		if (!isEmpty(components) || !isEmpty(sections)) {
 			return (
 				<Components
 					components={components}
 					sections={sections}
 					sidebar={sidebar}
+					singleExample={singleExample}
 				/>
 			);
 		}
@@ -52,13 +54,13 @@ export default class StyleGuide extends Component {
 	}
 
 	render() {
-		let { config, components, sections, sidebar } = this.props;
+		let { config, components, sections, sidebar, singleExample } = this.props;
 
 		return (
 			<StyleGuideRenderer
 				title={config.title}
 				homepageUrl={HOMEPAGE}
-				components={this.renderComponents(components, sections, sidebar)}
+				components={this.renderComponents(components, sections, sidebar, singleExample)}
 				sections={sections}
 				toc={this.renderTableOfContents(components, sections)}
 				sidebar={sidebar}

--- a/src/rsg-components/StyleGuide/StyleGuide.js
+++ b/src/rsg-components/StyleGuide/StyleGuide.js
@@ -20,12 +20,14 @@ export default class StyleGuide extends Component {
 	static childContextTypes = {
 		codeKey: PropTypes.number.isRequired,
 		config: PropTypes.object.isRequired,
+		singleExample: PropTypes.bool,
 	};
 
 	getChildContext() {
 		return {
 			codeKey: this.props.codeKey,
 			config: this.props.config,
+			singleExample: this.props.singleExample,
 		};
 	}
 
@@ -36,7 +38,6 @@ export default class StyleGuide extends Component {
 					components={components}
 					sections={sections}
 					sidebar={sidebar}
-					singleExample={singleExample}
 				/>
 			);
 		}

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,6 +1,7 @@
 import flatMap from 'lodash/flatMap';
 import isArray from 'lodash/isArray';
 import extend from 'lodash/extend';
+import isNaN from 'lodash/isNaN';
 
 export function setComponentsNames(components) {
 	components.map((component) => {
@@ -116,15 +117,37 @@ export function filterComponentsInSectionsByExactName(sections, name) {
 }
 
 /**
- * Returns component name from hash part or page URL:
- * http://localhost:3000/#!/Button → Button
+ * Returns an object containing component name and, optionally, an example index
+ * from hash part or page URL:
+ * http://localhost:3000/#!/Button → { targetComponentName: 'Button' }
+ * http://localhost:3000/#!/Button/1 → { targetComponentName: 'Button', targetComponentIndex: 1 }
  *
  * @param {string} [hash]
- * @returns {string}
+ * @returns {object}
  */
 export function getComponentNameFromHash(hash = window.location.hash) {
-	return hash.substr(0, 3) === '#!/'
-		? hash.substr(3)
-		: null
-	;
+	if (hash.substr(0, 3) === '#!/') {
+		const tokens = hash.substr(3).split('/');
+		const index = parseInt(tokens[1], 10);
+		return {
+			targetComponentName: tokens[0],
+			targetComponentIndex: isNaN(index) ? null : index,
+		};
+	}
+	return {};
+}
+
+/**
+ * Reurn a shallow copy of the given component with the examples array filtered
+ * to contain only the specified index:
+ * filterComponentExamples({ examples: [1,2,3], ...other }, 2) → { examples: [3], ...other }
+ *
+ * @param {object} component
+ * @param {number} index
+ * @returns {object}
+ */
+export function filterComponentExamples(component, index) {
+	const newComponent = Object.assign({}, component);
+	newComponent.examples = [component.examples[index]];
+	return newComponent;
 }

--- a/test/utils.utils.spec.js
+++ b/test/utils.utils.spec.js
@@ -162,10 +162,19 @@ test('should return components at any level with exact name', t => {
 
 test('should return important part of hash if it contains component name', t => {
 	const result = utils.getComponentNameFromHash('#!/Button');
-	t.deepEqual(result, 'Button');
+	t.deepEqual(result, { targetComponentName: 'Button', targetComponentIndex: null });
 });
 
-test('should return null if hash contains no component name', t => {
+test('should return an empty object if hash contains no component name', t => {
 	const result = utils.getComponentNameFromHash('Button');
-	t.deepEqual(result, null);
+	t.deepEqual(result, {});
+});
+
+// filterComponentExamples
+
+test('should return a shallow copy of the component with example filtered by given index', t => {
+	const comp = { examples: ['a', 'b', 'c', 'd'], other: 'info' };
+	const expectedOutput = { examples: ['c'], other: 'info' };
+	const result = utils.filterComponentExamples(comp, 2);
+	t.deepEqual(result, expectedOutput);
 });


### PR DESCRIPTION
Hi @sapegin 
first of all thanks for this project! I really love it and we use it in several projects.
In many of our library projects is the only available compiled output  and we often need to isolate a single example from a readme file.

This PR add the ability to isolate a single code example to simplify the development process.
Would you like to add this feature to the official repo? 

I'd love to have your feedback!
Cheers