### PR TITLE
Added config to debounce preview rendering while live editing

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -108,6 +108,10 @@ You can change settings in the `styleguide.config.js` file in your project’s r
   Type: `String`, default: `base16-light`<br>
   [CodeMirror theme](http://codemirror.net/demo/theme.html) name to use for syntax highlighting in examples.
 
+* **`previewDelay`**<br>
+  Type: `Number`, default: 0<br>
+  Debounce time used before render the changes from the editor. While inserting code the preview will not be updated.
+
 * **`getExampleFilename`**<br>
   Type: `Function`, default: finds `Readme.md` in the component folder<br>
   Function that returns examples file path for a given component path.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -109,7 +109,7 @@ You can change settings in the `styleguide.config.js` file in your project’s r
   [CodeMirror theme](http://codemirror.net/demo/theme.html) name to use for syntax highlighting in examples.
 
 * **`previewDelay`**<br>
-  Type: `Number`, default: 0<br>
+  Type: `Number`, default: 500<br>
   Debounce time used before render the changes from the editor. While inserting code the preview will not be updated.
 
 * **`getExampleFilename`**<br>

--- a/loaders/styleguide.loader.js
+++ b/loaders/styleguide.loader.js
@@ -141,6 +141,7 @@ module.exports.pitch = function() {
 		'title',
 		'highlightTheme',
 		'showCode',
+		'previewDelay',
 	]);
 
 	const code = toCode({

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -9,6 +9,7 @@ const semverUtils = require('semver-utils');
 const prettyjson = require('prettyjson');
 const merge = require('lodash/merge');
 const isFinite = require('lodash/isFinite');
+const isUndefined = require('lodash/isUndefined');
 const utils = require('./utils/utils');
 const consts = require('./consts');
 const StyleguidistError = require('./utils/error');
@@ -172,7 +173,7 @@ function validateConfig(config) {
 		throw new StyleguidistError('Styleguidist: "defaultExample" option must be either false, true, ' +
 			'or a string path to a markdown file.');
 	}
-	if (!isFinite(config.previewDelay)) {
+	if (!isUndefined(config.previewDelay) && !isFinite(config.previewDelay)) {
 		throw new StyleguidistError('Styleguidist: "previewDelay" option must be a positive number.');
 	}
 }

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -8,6 +8,7 @@ const findup = require('findup');
 const semverUtils = require('semver-utils');
 const prettyjson = require('prettyjson');
 const merge = require('lodash/merge');
+const isFinite = require('lodash/isFinite');
 const utils = require('./utils/utils');
 const consts = require('./consts');
 const StyleguidistError = require('./utils/error');
@@ -28,6 +29,7 @@ const DEFAULT_CONFIG = {
 	serverHost: 'localhost',
 	serverPort: 3000,
 	highlightTheme: 'base16-light',
+	previewDelay: 500,
 	verbose: false,
 	getExampleFilename: componentpath => path.join(path.dirname(componentpath), 'Readme.md'),
 	getComponentPathLine: componentpath => componentpath,
@@ -169,6 +171,9 @@ function validateConfig(config) {
 	if (config.defaultExample && (config.defaultExample !== true && typeof config.defaultExample !== 'string')) {
 		throw new StyleguidistError('Styleguidist: "defaultExample" option must be either false, true, ' +
 			'or a string path to a markdown file.');
+	}
+	if (!isFinite(config.previewDelay)) {
+		throw new StyleguidistError('Styleguidist: "previewDelay" option must be a positive number.');
 	}
 }
 

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -1,4 +1,6 @@
 import React, { Component, PropTypes } from 'react';
+import debounce from 'lodash/debounce';
+import isFinite from 'lodash/isFinite';
 import PlaygroundRenderer from 'rsg-components/Playground/PlaygroundRenderer';
 
 export default class Playground extends Component {
@@ -16,7 +18,11 @@ export default class Playground extends Component {
 	constructor(props, context) {
 		super(props, context);
 		const { code } = props;
-		const { showCode } = context.config;
+		const { previewDelay, showCode } = context.config;
+
+		// `previewDelay` may not be defined or have an invalid value, by defayult is disabled.
+		this.previewDelay = isFinite(previewDelay) && previewDelay > 0 ? previewDelay : 0;
+
 		this.state = {
 			code,
 			showCode,
@@ -37,10 +43,33 @@ export default class Playground extends Component {
 		);
 	}
 
+	componentWillUnmount() {
+		// clear pending changes before unmount
+		if (this.queuedChange) {
+			this.queuedChange.cancel();
+		}
+	}
+
 	handleChange(code) {
-		this.setState({
+		// clear pending changes before proceed
+		if (this.queuedChange) {
+			this.queuedChange.cancel();
+		}
+
+		// stored update action
+		const queuedChange = () => this.setState({
 			code,
 		});
+
+		if (this.previewDelay) {
+			// if previewDelay is enabled debounce the code
+			this.queuedChange = debounce(queuedChange, 1000);
+			this.queuedChange();
+		}
+		else {
+			// otherwise execute it
+			queuedChange();
+		}
 	}
 
 	handleCodeToggle() {

--- a/src/rsg-components/Playground/Playground.js
+++ b/src/rsg-components/Playground/Playground.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import debounce from 'lodash/debounce';
-import isFinite from 'lodash/isFinite';
 import PlaygroundRenderer from 'rsg-components/Playground/PlaygroundRenderer';
 
 export default class Playground extends Component {
@@ -18,10 +17,7 @@ export default class Playground extends Component {
 	constructor(props, context) {
 		super(props, context);
 		const { code } = props;
-		const { previewDelay, showCode } = context.config;
-
-		// `previewDelay` may not be defined or have an invalid value, by defayult is disabled.
-		this.previewDelay = isFinite(previewDelay) && previewDelay > 0 ? previewDelay : 0;
+		const { showCode } = context.config;
 
 		this.state = {
 			code,
@@ -61,9 +57,11 @@ export default class Playground extends Component {
 			code,
 		});
 
-		if (this.previewDelay) {
+		const { previewDelay } = context.config;
+
+		if (previewDelay) {
 			// if previewDelay is enabled debounce the code
-			this.queuedChange = debounce(queuedChange, 1000);
+			this.queuedChange = debounce(queuedChange, previewDelay);
 			this.queuedChange();
 		}
 		else {


### PR DESCRIPTION
This is something I've often loved to have using `react-styleguidist`. Basically it enables to write code in codemirror without having tens of updates on the preview panel. As side-effect is also less probable that while writing the preview will crash because of incomplete expressions.

Is this something you'd like to add to the project?