### PR TITLE
Preview container to overflow the floating components

### DIFF
--- a/src/rsg-components/Playground/Playground.css
+++ b/src/rsg-components/Playground/Playground.css
@@ -8,6 +8,7 @@
 .preview {
 	margin-bottom: 3px;
 	padding: 15px;
+	overflow: auto;
 }
 
 .codeToggle {


### PR DESCRIPTION
If a component has `float: left` (or another float) in styles, current `.ReactStyleguidist-Playground__preview` container does not give it enough space to be rendered. With `overflow: auto` I can ensure that the container's height is enough.